### PR TITLE
feat: tolerate resume generation errors

### DIFF
--- a/components/templates/Classic.jsx
+++ b/components/templates/Classic.jsx
@@ -1,42 +1,60 @@
-export default function Classic({ data }) {
-  const fmt = (s) => (s ? s.replace(/-/g, "–") : "");
+export default function Classic({ data = {} }) {
+  const fmt = (s) => (s ? String(s).replace(/-/g, "–") : "");
+  const links = Array.isArray(data.links) ? data.links : [];
+  const skills = Array.isArray(data.skills) ? data.skills : [];
+  const exp = Array.isArray(data.experience) ? data.experience : [];
+  const edu = Array.isArray(data.education) ? data.education : [];
+
   return (
     <div className="resume">
       <header>
-        <h1>{data.name}</h1>
-        <div className="muted">{[data.title, data.location].filter(Boolean).join(" • ")}</div>
-        <div className="muted">
-          {[data.email, data.phone, ...(data.links||[]).map(l=>l.url)].filter(Boolean).join(" · ")}
-        </div>
+        {data.name && <h1>{data.name}</h1>}
+        {(data.title || data.location) && (
+          <div className="muted">{[data.title, data.location].filter(Boolean).join(" • ")}</div>
+        )}
+        {(data.email || data.phone || links.length) && (
+          <div className="muted">
+            {[data.email, data.phone, ...links.map((l) => l?.url).filter(Boolean)].join(" · ")}
+          </div>
+        )}
         <div className="rule" />
       </header>
 
       {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
 
-      {Array.isArray(data.skills) && data.skills.length > 0 && (
+      {skills.length > 0 && (
         <>
           <h2>Skills</h2>
-          <div>{data.skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+          <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
         </>
       )}
 
-      <h2>Experience</h2>
-      {data.experience.map((x, i) => (
+      {exp.length > 0 && <h2>Experience</h2>}
+      {exp.map((x, i) => (
         <section key={i}>
-          <div className="row"><strong>{x.company} — {x.role}</strong><span className="muted">{fmt(x.start)} – {x.end ? fmt(x.end) : "Present"}</span></div>
+          {(x.company || x.role || x.start || x.end) && (
+            <div className="row">
+              <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
+              {(x.start || x.end != null) && (
+                <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
+              )}
+            </div>
+          )}
           {x.location && <div className="muted">{x.location}</div>}
-          <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+          {Array.isArray(x.bullets) && x.bullets.length > 0 && (
+            <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+          )}
         </section>
       ))}
 
-      {data.education?.length > 0 && (
-        <>
-          <h2>Education</h2>
-          {data.education.map((e, i) => (
-            <div className="row" key={i}><div><strong>{e.school}</strong> — {e.degree}</div><div className="muted">{fmt(e.start)} – {fmt(e.end)}</div></div>
-          ))}
-        </>
-      )}
+      {edu.length > 0 && <h2>Education</h2>}
+      {edu.map((e, i) => (
+        <div className="row" key={i}>
+          <div><strong>{e.school}</strong>{e.degree ? ` — ${e.degree}` : ""}</div>
+          {(e.start || e.end) && <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>}
+        </div>
+      ))}
     </div>
   );
 }
+

--- a/components/templates/TwoCol.jsx
+++ b/components/templates/TwoCol.jsx
@@ -1,24 +1,42 @@
-export default function TwoCol({ data }) {
-  const fmt = (s) => (s ? s.replace(/-/g, "–") : "");
+export default function TwoCol({ data = {} }) {
+  const fmt = (s) => (s ? String(s).replace(/-/g, "–") : "");
+  const links = Array.isArray(data.links) ? data.links : [];
+  const skills = Array.isArray(data.skills) ? data.skills : [];
+  const exp = Array.isArray(data.experience) ? data.experience : [];
+  const edu = Array.isArray(data.education) ? data.education : [];
+
   return (
     <div className="resume resumeGrid">
       <aside className="sidebar">
-        <h1 style={{margin:'0 0 4px 0'}}>{data.name}</h1>
-        <div className="muted" style={{marginBottom:8}}>{[data.title, data.location].filter(Boolean).join(" • ")}</div>
-        <div className="muted" style={{marginBottom:8}}>
-          {[data.email, data.phone, ...(data.links||[]).map(l=>l.url)].filter(Boolean).join(" · ")}
-        </div>
-        {Array.isArray(data.skills) && data.skills.length > 0 && (
+        {data.name && <h1 style={{margin:'0 0 4px 0'}}>{data.name}</h1>}
+        {(data.title || data.location) && (
+          <div className="muted" style={{marginBottom:8}}>
+            {[data.title, data.location].filter(Boolean).join(" • ")}
+          </div>
+        )}
+        {(data.email || data.phone || links.length) && (
+          <div className="muted" style={{marginBottom:8}}>
+            {[data.email, data.phone, ...links.map((l)=>l?.url).filter(Boolean)].join(" · ")}
+          </div>
+        )}
+
+        {skills.length > 0 && (
           <>
             <h2>Skills</h2>
-            <div>{data.skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+            <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
           </>
         )}
-        {data.education?.length > 0 && (
+
+        {edu.length > 0 && (
           <>
             <h2>Education</h2>
-            {data.education.map((e, i) => (
-              <div key={i}><strong>{e.school}</strong><div className="muted">{e.degree} • {fmt(e.start)} – {fmt(e.end)}</div></div>
+            {edu.map((e, i) => (
+              <div key={i}>
+                <strong>{e.school}</strong>
+                <div className="muted">
+                  {[e.degree, e.start && fmt(e.start), e.end && fmt(e.end)].filter(Boolean).join(" • ")}
+                </div>
+              </div>
             ))}
           </>
         )}
@@ -26,15 +44,25 @@ export default function TwoCol({ data }) {
 
       <main>
         {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
-        <h2>Experience</h2>
-        {data.experience.map((x, i) => (
+        {exp.length > 0 && <h2>Experience</h2>}
+        {exp.map((x, i) => (
           <section key={i}>
-            <div className="row"><strong>{x.company} — {x.role}</strong><span className="muted">{fmt(x.start)} – {x.end ? fmt(x.end) : "Present"}</span></div>
+            {(x.company || x.role || x.start || x.end) && (
+              <div className="row">
+                <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
+                {(x.start || x.end != null) && (
+                  <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
+                )}
+              </div>
+            )}
             {x.location && <div className="muted">{x.location}</div>}
-            <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+            {Array.isArray(x.bullets) && x.bullets.length > 0 && (
+              <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+            )}
           </section>
         ))}
       </main>
     </div>
   );
 }
+

--- a/lib/normalizeResume.js
+++ b/lib/normalizeResume.js
@@ -1,0 +1,67 @@
+export function normalizeResumeData(raw = {}) {
+  const out = { ...raw };
+
+  // Ensure arrays
+  out.skills = Array.isArray(out.skills) ? out.skills.map(String) : [];
+  out.experience = Array.isArray(out.experience) ? out.experience : [];
+  out.education = Array.isArray(out.education) ? out.education : [];
+  out.links = Array.isArray(out.links) ? out.links : [];
+
+  // Links: string -> {label,url}
+  out.links = out.links.map((l) => {
+    if (typeof l === "string") {
+      const label = l.replace(/^https?:\/\/(www\.)?/, "").slice(0, 30);
+      return { label, url: l };
+    }
+    return {
+      label: String(l?.label || l?.url || "").slice(0, 30),
+      url: String(l?.url || ""),
+    };
+  });
+
+  // Helpers
+  const toArray = (v) =>
+    Array.isArray(v)
+      ? v.map(String)
+      : typeof v === "string"
+      ? v.split(/\n+|•|\u2022/).map((s) => s.trim()).filter(Boolean)
+      : [];
+
+  const toYmOrNull = (v) => {
+    if (v == null) return null;
+    const s = String(v).trim();
+    if (/present/i.test(s)) return null;
+    // Coerce "May 2021" -> "2021-05" if possible; else keep raw
+    const m = s.match(
+      /(20\d{2}|19\d{2})[-/ .]?(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|\d{1,2})/i
+    );
+    if (!m) return s;
+    const year = m[1];
+    const map = {
+      jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+      jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+    };
+    const m2 = /^\d+$/.test(m[2]) ? Number(m[2]) : map[m[2].toLowerCase()];
+    return year && m2 ? `${year}-${String(m2).padStart(2, "0")}` : s;
+  };
+
+  // Experience: coerce bullets and dates; keep row if it has any useful content
+  out.experience = out.experience
+    .map((x) => ({
+      company: String(x?.company || "").trim(),
+      role: String(x?.role || "").trim(),
+      start: toYmOrNull(x?.start),
+      end: toYmOrNull(x?.end),
+      location: x?.location ? String(x.location) : undefined,
+      bullets: toArray(x?.bullets),
+    }))
+    .filter((e) => e.company || e.role || e.bullets.length);
+
+  // Scalar fields as strings
+  ["name", "title", "email", "phone", "location", "summary"].forEach((k) => {
+    if (out[k] != null) out[k] = String(out[k]);
+  });
+
+  return out;
+}
+

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -1,62 +1,79 @@
 import os from "os";
-import path from "path";
 import fs from "fs";
 import formidable from "formidable";
 import pdfParse from "pdf-parse";
 import mammoth from "mammoth";
 import OpenAI from "openai";
-import { ResumeData } from "../../lib/resumeSchema";
+import { normalizeResumeData } from "../../lib/normalizeResume";
 
 export const config = { api: { bodyParser: false } };
 
-function firstFile(f){ if(!f) return; return Array.isArray(f)?f[0]:f; }
+function firstFile(f) { return Array.isArray(f) ? f[0] : f; }
 
-async function extractTextFromFile(file){
-  const f = firstFile(file); if(!f) return "";
-  const p = f.filepath || f.path; const mime = (f.mimetype || f.type || "").toLowerCase();
-  if(!p) return ""; const buf = fs.readFileSync(p);
-  if (mime.includes("pdf") || p.toLowerCase().endsWith(".pdf")) { const r = await pdfParse(buf); return r.text || ""; }
-  if (mime.includes("wordprocessingml") || p.toLowerCase().endsWith(".docx")) { const { value } = await mammoth.extractRawText({ buffer: buf }); return value || ""; }
+async function extractTextFromFile(file) {
+  const f = firstFile(file); if (!f) return "";
+  const p = f.filepath || f.path;
+  const mime = (f.mimetype || f.type || "").toLowerCase();
+  if (!p) return "";
+  const buf = fs.readFileSync(p);
+  if (mime.includes("pdf") || p.toLowerCase().endsWith(".pdf")) {
+    const r = await pdfParse(buf); return r.text || "";
+  }
+  if (mime.includes("wordprocessingml") || p.toLowerCase().endsWith(".docx")) {
+    const { value } = await mammoth.extractRawText({ buffer: buf }); return value || "";
+  }
   return buf.toString("utf8");
 }
 
-async function parseForm(req){
-  const form = formidable({ multiples:true, uploadDir: os.tmpdir(), keepExtensions:true, maxFileSize: 20*1024*1024 });
-  return new Promise((resolve,reject)=>form.parse(req,(err,fields,files)=>err?reject(err):resolve({fields,files})));
+function parseForm(req) {
+  const form = formidable({
+    multiples: true, uploadDir: os.tmpdir(),
+    keepExtensions: true, maxFileSize: 20 * 1024 * 1024
+  });
+  return new Promise((resolve, reject) => {
+    form.parse(req, (err, fields, files) => err ? reject(err) : resolve({ fields, files }));
+  });
 }
 
-function safeJSON(s){
-  try { return JSON.parse(s); } catch { return null; }
+// JSON helpers
+function stripCodeFence(s = "") {
+  const m = String(s).trim().match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return m ? m[1] : s;
+}
+function safeJSON(s) {
+  try { return JSON.parse(stripCodeFence(s)); } catch { return null; }
 }
 
-export default async function handler(req,res){
+export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
   if (!process.env.OPENAI_API_KEY) return res.status(500).json({ error: "Missing OPENAI_API_KEY" });
 
-  try{
+  try {
     const { fields, files } = await parseForm(req);
     const resumeText = await extractTextFromFile(files?.resume);
     const coverText  = await extractTextFromFile(files?.coverLetter);
-    const jobDesc    = Array.isArray(fields?.jobDesc) ? fields.jobDesc[0] : fields?.jobDesc || "";
-    if (!resumeText && !coverText) return res.status(400).json({ error: "No readable files", code:"E_NO_FILES" });
-    if (!jobDesc || jobDesc.trim().length < 30) return res.status(400).json({ error: "Job description too short", code:"E_BAD_INPUT" });
+    const jobDesc    = Array.isArray(fields?.jobDesc) ? fields.jobDesc[0] : (fields?.jobDesc || "");
+
+    if (!resumeText && !coverText) {
+      return res.status(400).json({ error: "No readable files", code: "E_NO_FILES" });
+    }
+    if (!jobDesc || jobDesc.trim().length < 30) {
+      return res.status(400).json({ error: "Job description too short", code: "E_BAD_INPUT" });
+    }
 
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
     const system = `You output ONLY JSON with keys: coverLetterText (string) and resumeData (object).
-resumeData must match the schema:
-{ "name": string, "title?": string, "email": string, "phone?": string, "location?": string,
-  "links": [{ "label": string, "url": string }] (optional),
-  "summary?": string, "skills": [string],
-  "experience": [{ "company": string, "role": string, "start": "YYYY-MM", "end": "YYYY-MM" | null, "bullets": [string], "location?": string }],
-  "education": [{ "school": string, "degree": string, "start": "YYYY-MM", "end": "YYYY-MM" }]
-}
-Never fabricate employers, dates, credentials, or numbers. If unknown, omit field.`;
+resumeData should contain fields like:
+- name, title?, email?, phone?, location?, summary?
+- links: array (items may be {label,url} or strings)
+- skills: array of strings
+- experience: array of { company, role, start, end|null, bullets[], location? }
+- education: array of { school, degree, start, end }
+Never fabricate employers, dates, credentials, or numbers. If unknown, omit. No prose, no markdown fences.`;
 
     const user = `
-Generate JSON for a tailored cover letter and a revised resume.
-- Keep ATS-friendly writing: concise bullets with strong verbs, no tables/icons.
-- If skills are missing, leverage adjacent experience honestly.
+Generate JSON for a tailored cover letter and a revised resume (ATS-friendly).
 INPUTS
 Job Description:
 ${jobDesc}
@@ -71,24 +88,25 @@ ${coverText}
     const resp = await client.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0.3,
-      messages: [{ role:"system", content: system }, { role:"user", content: user }]
+      // If supported on your account, uncomment for stricter JSON:
+      // response_format: { type: "json_object" },
+      messages: [{ role: "system", content: system }, { role: "user", content: user }]
     });
 
     const raw = resp.choices?.[0]?.message?.content || "";
     const json = safeJSON(raw);
-    if (!json || typeof json.coverLetterText !== "string" || typeof json.resumeData !== "object") {
+    if (!json) {
+      // Give the client *something* useful without crashing
       return res.status(502).json({ error: "Bad model output", code: "E_BAD_MODEL_OUTPUT", raw });
     }
 
-    // Validate resumeData against schema; if invalid, return error
-    const parsed = ResumeData.safeParse(json.resumeData);
-    if (!parsed.success) {
-      return res.status(502).json({ error: "Invalid resume shape", code: "E_SCHEMA", details: parsed.error.flatten() });
-    }
+    const resumeData = normalizeResumeData(json.resumeData || {});
+    const coverLetter = String(json.coverLetterText || "");
 
-    return res.status(200).json({ coverLetter: json.coverLetterText, resumeData: parsed.data });
-  }catch(err){
+    return res.status(200).json({ coverLetter, resumeData });
+  } catch (err) {
     console.error(err);
     return res.status(500).json({ error: "Server error", detail: String(err?.message || err) });
   }
 }
+

--- a/pages/index.js
+++ b/pages/index.js
@@ -48,9 +48,11 @@ export default function Home() {
 
       const res = await fetch("/api/generate", { method:"POST", body: formData });
       const data = await res.json();
-      if (!res.ok) throw new Error(data?.error || "Generation failed");
-
-      setResult(data);
+      if (!res.ok) {
+        setError(`${data?.code || "E_UNKNOWN"}: ${data?.error || "Request failed"}`);
+        return;
+      }
+      setResult(data); // { coverLetter, resumeData }
     }catch(err){
       setError(String(err.message || err));
     }finally{


### PR DESCRIPTION
## Summary
- Add normalizer to coerce model JSON into consistent resume shape
- Make `/api/generate` parse JSON tolerant and always return data
- Render templates defensively against missing fields
- Surface API error codes in the UI

## Testing
- `node --check lib/normalizeResume.js`
- `node --check pages/api/generate.js`
- ⚠️ `node --check components/templates/Classic.jsx` (unsupported .jsx extension)
- ⚠️ `node --check components/templates/TwoCol.jsx` (unsupported .jsx extension)
- ⚠️ `npm test` (Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b9fdbf7bc88329b241fd4ac3632da7