### PR TITLE
Revamp template selection and add new resume layouts

### DIFF
--- a/components/templates/Centered.jsx
+++ b/components/templates/Centered.jsx
@@ -1,0 +1,59 @@
+export default function Centered({ data = {} }) {
+  const fmt = (s) => (s ? String(s).replace(/-/g, "–") : "");
+  const links = Array.isArray(data.links) ? data.links : [];
+  const skills = Array.isArray(data.skills) ? data.skills : [];
+  const exp = Array.isArray(data.experience) ? data.experience : [];
+  const edu = Array.isArray(data.education) ? data.education : [];
+
+  return (
+    <div className="resume centeredHeader">
+      <header>
+        {data.name && <h1>{data.name}</h1>}
+        {(data.title || data.location) && (
+          <div className="muted">{[data.title, data.location].filter(Boolean).join(" • ")}</div>
+        )}
+        {(data.email || data.phone || links.length) && (
+          <div className="muted">
+            {[data.email, data.phone, ...links.map((l) => l?.url).filter(Boolean)].join(" · ")}
+          </div>
+        )}
+        <div className="rule" />
+      </header>
+
+      {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
+
+      {skills.length > 0 && (
+        <>
+          <h2>Skills</h2>
+          <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+        </>
+      )}
+
+      {exp.length > 0 && <h2>Experience</h2>}
+      {exp.map((x, i) => (
+        <section key={i}>
+          {(x.company || x.role || x.start || x.end) && (
+            <div className="row">
+              <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
+              {(x.start || x.end != null) && (
+                <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
+              )}
+            </div>
+          )}
+          {x.location && <div className="muted">{x.location}</div>}
+          {Array.isArray(x.bullets) && x.bullets.length > 0 && (
+            <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+          )}
+        </section>
+      ))}
+
+      {edu.length > 0 && <h2>Education</h2>}
+      {edu.map((e, i) => (
+        <div className="row" key={i}>
+          <div><strong>{e.school}</strong>{e.degree ? ` — ${e.degree}` : ""}</div>
+          {(e.start || e.end) && <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/templates/Sidebar.jsx
+++ b/components/templates/Sidebar.jsx
@@ -1,0 +1,67 @@
+export default function Sidebar({ data = {} }) {
+  const fmt = (s) => (s ? String(s).replace(/-/g, "–") : "");
+  const links = Array.isArray(data.links) ? data.links : [];
+  const skills = Array.isArray(data.skills) ? data.skills : [];
+  const exp = Array.isArray(data.experience) ? data.experience : [];
+  const edu = Array.isArray(data.education) ? data.education : [];
+
+  return (
+    <div className="resume resumeGrid">
+      <aside className="sidebar">
+        {data.name && <h1 style={{margin:'0 0 4px 0'}}>{data.name}</h1>}
+        {(data.title || data.location) && (
+          <div className="muted" style={{marginBottom:8}}>
+            {[data.title, data.location].filter(Boolean).join(" • ")}
+          </div>
+        )}
+        {(data.email || data.phone || links.length) && (
+          <div className="muted" style={{marginBottom:8}}>
+            {[data.email, data.phone, ...links.map((l)=>l?.url).filter(Boolean)].join(" · ")}
+          </div>
+        )}
+
+        {skills.length > 0 && (
+          <>
+            <h2>Skills</h2>
+            <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+          </>
+        )}
+
+        {edu.length > 0 && (
+          <>
+            <h2>Education</h2>
+            {edu.map((e, i) => (
+              <div key={i}>
+                <strong>{e.school}</strong>
+                <div className="muted">
+                  {[e.degree, e.start && fmt(e.start), e.end && fmt(e.end)].filter(Boolean).join(" • ")}
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+      </aside>
+
+      <main className="sidebarMain">
+        {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
+        {exp.length > 0 && <h2>Experience</h2>}
+        {exp.map((x, i) => (
+          <section key={i}>
+            {(x.company || x.role || x.start || x.end) && (
+              <div className="row">
+                <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
+                {(x.start || x.end != null) && (
+                  <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
+                )}
+              </div>
+            )}
+            {x.location && <div className="muted">{x.location}</div>}
+            {Array.isArray(x.bullets) && x.bullets.length > 0 && (
+              <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+            )}
+          </section>
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,33 +2,32 @@ import { useMemo, useRef, useState } from "react";
 import Head from "next/head";
 import Classic from "../components/templates/Classic";
 import TwoCol from "../components/templates/TwoCol";
+import Centered from "../components/templates/Centered";
+import Sidebar from "../components/templates/Sidebar";
 import { useReactToPrint } from "react-to-print";
+
+const TEMPLATE_INFO = {
+  classic: "Single-column, ATS-first. Clean headings, great for online parsers and conservative employers.",
+  twoCol: "Two columns with a compact sidebar. Good when you have many skills and want dense use of space.",
+  centered: "Centered header with balanced sections. Reads modern while staying recruiter-friendly.",
+  sidebar: "Prominent left sidebar for skills/education; main column for experience. Great for showcasing stack breadth."
+};
 
 export default function Home() {
   const [resume, setResume] = useState(null);
-  const [coverLetter, setCoverLetter] = useState(null);
   const [jobDesc, setJobDesc] = useState("");
   const [result, setResult] = useState(null);          // { coverLetter, resumeData }
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const [template, setTemplate] = useState("classic"); // "classic" | "twoCol"
-  const [useMyLayout, setUseMyLayout] = useState(true);
-  const [exportType, setExportType] = useState("pdf"); // "pdf" | "docx"
+  const [template, setTemplate] = useState("classic"); // classic | twoCol | centered | sidebar
+  const [exportType, setExportType] = useState("pdf"); // pdf | docx
 
   const compRef = useRef(null);
-  const handlePrint = useReactToPrint({ content: () => compRef.current });
-
-  async function inferTemplateIfNeeded() {
-    if (!useMyLayout || !resume) return;
-    const formData = new FormData();
-    formData.append("resume", resume);
-    try{
-      const r = await fetch("/api/infer-layout", { method:"POST", body: formData });
-      const j = await r.json();
-      if (j?.template === "twoCol" || j?.template === "classic") setTemplate(j.template);
-    }catch(_) {}
-  }
+  const handlePrint = useReactToPrint({
+    content: () => compRef.current,
+    documentTitle: `${result?.resumeData?.name || "Resume"}`
+  });
 
   async function handleSubmit(e){
     e.preventDefault();
@@ -37,22 +36,16 @@ export default function Home() {
     if (!resume) return setError("Please upload a resume (PDF or DOCX).");
     if (!jobDesc.trim()) return setError("Please paste a job description.");
 
-    await inferTemplateIfNeeded();
-
     try{
       setLoading(true);
       const formData = new FormData();
       formData.append("resume", resume);
-      if (coverLetter) formData.append("coverLetter", coverLetter);
       formData.append("jobDesc", jobDesc);
 
       const res = await fetch("/api/generate", { method:"POST", body: formData });
       const data = await res.json();
-      if (!res.ok) {
-        setError(`${data?.code || "E_UNKNOWN"}: ${data?.error || "Request failed"}`);
-        return;
-      }
-      setResult(data); // { coverLetter, resumeData }
+      if (!res.ok) throw new Error(data?.error || "Generation failed");
+      setResult(data);
     }catch(err){
       setError(String(err.message || err));
     }finally{
@@ -75,7 +68,14 @@ export default function Home() {
     document.body.appendChild(a); a.click(); URL.revokeObjectURL(url); a.remove();
   }
 
-  const TemplateView = useMemo(()=> template === "twoCol" ? TwoCol : Classic, [template]);
+  const TemplateView = useMemo(() => {
+    switch (template) {
+      case "twoCol": return TwoCol;
+      case "centered": return Centered;
+      case "sidebar": return Sidebar;
+      default: return Classic;
+    }
+  }, [template]);
 
   return (
     <>
@@ -85,59 +85,80 @@ export default function Home() {
         <meta name="keywords" content="AI resume, cover letter, ATS, PDF, DOCX, templates" />
       </Head>
 
-      <main style={{maxWidth:980, margin:"24px auto", padding:"0 12px"}}>
-        <h1 style={{fontSize:24, marginBottom:8}}>AI Résumé + Cover Letter</h1>
+      {/* Two-column screen layout: controls left, results right */}
+      <main style={{maxWidth:1200, margin:"24px auto", padding:"0 16px", display:"grid", gridTemplateColumns:"360px 1fr", gap:20}}>
+        {/* LEFT: Controls */}
+        <section style={{display:"grid", gap:12, alignContent:"start"}}>
+          <h1 style={{fontSize:24, marginBottom:4}}>AI Résumé + Cover Letter</h1>
 
-        <form onSubmit={handleSubmit} style={{display:"grid", gap:12, marginBottom:16}}>
-          <div>
-            <label>Upload resume (PDF/DOCX): </label>
-            <input type="file" accept=".pdf,.docx,.txt" onChange={e=>setResume(e.target.files?.[0]||null)} />
-          </div>
-          <div>
-            <label>Optional previous cover letter: </label>
-            <input type="file" accept=".pdf,.docx,.txt" onChange={e=>setCoverLetter(e.target.files?.[0]||null)} />
-          </div>
-          <div>
-            <label>Job description:</label>
-            <textarea value={jobDesc} onChange={e=>setJobDesc(e.target.value)} rows={8} style={{width:"100%"}} />
-          </div>
-
-          <div style={{display:"flex", gap:16, alignItems:"center"}}>
-            <label><input type="checkbox" checked={useMyLayout} onChange={e=>setUseMyLayout(e.target.checked)} /> Use my CV layout (auto-detect)</label>
-            <span style={{opacity:.6}}>Detected/Chosen template:</span>
-            <select value={template} onChange={e=>setTemplate(e.target.value)}>
-              <option value="classic">Classic (ATS)</option>
-              <option value="twoCol">Two-Column</option>
-            </select>
-            <span style={{marginLeft:12, opacity:.6}}>Export:</span>
-            <select value={exportType} onChange={e=>setExportType(e.target.value)}>
-              <option value="pdf">PDF</option>
-              <option value="docx">DOCX</option>
-            </select>
-            <button type="submit" disabled={loading}>{loading ? "Generating..." : "Generate"}</button>
-          </div>
-        </form>
-
-        {error && <div style={{color:"#b91c1c", marginBottom:8}}>{error}</div>}
-
-        {result?.resumeData && (
-          <section style={{border:"1px solid #e5e7eb", borderRadius:8, padding:12, background:"#fff"}}>
-            <div ref={compRef}><TemplateView data={result.resumeData} /></div>
-            <div style={{display:"flex", gap:8, marginTop:10}}>
-              <button onClick={() => exportType==="pdf" ? handlePrint() : downloadDocx()}>
-                {exportType==="pdf" ? "Download PDF" : "Download DOCX"}
-              </button>
-              <button onClick={handlePrint}>Print</button>
+          <form onSubmit={handleSubmit} style={{display:"grid", gap:12}}>
+            <div>
+              <label style={{display:"block", fontWeight:600, marginBottom:6}}>Upload resume (PDF/DOCX):</label>
+              <input type="file" accept=".pdf,.docx,.txt" onChange={e=>setResume(e.target.files?.[0]||null)} />
             </div>
-          </section>
-        )}
 
-        {result?.coverLetter && (
-          <section style={{marginTop:18}}>
-            <h2>Cover Letter</h2>
-            <textarea readOnly value={result.coverLetter} rows={10} style={{width:"100%"}} />
-          </section>
-        )}
+            <div>
+              <label style={{display:"block", fontWeight:600, marginBottom:6}}>Job description:</label>
+              <textarea value={jobDesc} onChange={e=>setJobDesc(e.target.value)} rows={10} style={{width:"100%"}} />
+              <div style={{marginTop:6}}>
+                <button type="button" onClick={()=>setJobDesc("")}>Clear</button>
+              </div>
+            </div>
+
+            <div>
+              <label style={{display:"block", fontWeight:600, marginBottom:6}}>Select a template:</label>
+              <select value={template} onChange={e=>setTemplate(e.target.value)}>
+                <option value="classic">Classic (ATS)</option>
+                <option value="twoCol">Two-Column</option>
+                <option value="centered">Centered Header</option>
+                <option value="sidebar">Sidebar</option>
+              </select>
+              <div style={{marginTop:8, fontSize:12, color:"#475569", border:"1px solid #e2e8f0", borderRadius:6, padding:"8px 10px", background:"#fff"}}>
+                {TEMPLATE_INFO[template]}
+              </div>
+            </div>
+
+            <div style={{display:"flex", gap:12, alignItems:"center"}}>
+              <div>
+                <label style={{display:"block", fontWeight:600, marginBottom:6}}>Export:</label>
+                <select value={exportType} onChange={e=>setExportType(e.target.value)}>
+                  <option value="pdf">PDF</option>
+                  <option value="docx">DOCX</option>
+                </select>
+              </div>
+
+              <button type="submit" disabled={loading}>
+                {loading ? "Generating..." : "Generate"}
+              </button>
+            </div>
+          </form>
+
+          {error && <div style={{color:"#b91c1c"}}>{error}</div>}
+        </section>
+
+        {/* RIGHT: Results container */}
+        <section style={{border:"1px solid #e5e7eb", borderRadius:8, padding:12, background:"#fff", overflow:"auto", maxHeight:"85vh"}}>
+          {result?.resumeData ? (
+            <>
+              <div ref={compRef}><TemplateView data={result.resumeData} /></div>
+              <div style={{display:"flex", gap:8, marginTop:10}}>
+                <button onClick={() => exportType==="pdf" ? handlePrint() : downloadDocx()}>
+                  {exportType==="pdf" ? "Download PDF" : "Download DOCX"}
+                </button>
+                <button onClick={handlePrint}>Print</button>
+              </div>
+
+              {result?.coverLetter && (
+                <div style={{marginTop:18}}>
+                  <h2>Cover Letter</h2>
+                  <textarea readOnly value={result.coverLetter} rows={10} style={{width:"100%"}} />
+                </div>
+              )}
+            </>
+          ) : (
+            <div style={{opacity:.6}}>Your generated résumé will appear here.</div>
+          )}
+        </section>
       </main>
     </>
   );

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -1,8 +1,8 @@
 :root {
-  --ink: #0f172a;      /* text */
-  --muted: #64748b;    /* secondary text */
-  --rule: #e2e8f0;     /* borders */
-  --accent: #1a73e8;   /* link color */
+  --ink: #0f172a;
+  --muted: #64748b;
+  --rule: #e2e8f0;
+  --accent: #1a73e8;
   --bg: #ffffff;
 }
 .resume {
@@ -22,12 +22,18 @@
 .resume a { color: var(--accent); text-decoration: none; }
 .resume .rule { border-top: 1px solid var(--rule); margin: 10px 0; }
 
-/* Two-column template layout */
-.resumeGrid {
-  display: grid; grid-template-columns: 240px 1fr; gap: 18px;
-}
+/* Two-column base */
+.resumeGrid { display: grid; grid-template-columns: 240px 1fr; gap: 18px; }
 .sidebar h2 { margin-top: 0; }
 .sidebar .pill { display:block; margin: 3px 0; }
+
+/* Centered header variant */
+.centeredHeader header { text-align: center; }
+.centeredHeader .rule { margin: 12px auto; width: 96%; }
+
+/* Sidebar variant small vertical divider */
+.sidebarMain { position: relative; }
+.sidebarMain::before { content:""; position:absolute; left:-9px; top:0; bottom:0; width:1px; background: var(--rule); }
 
 @media print {
   @page { margin: 14mm; }


### PR DESCRIPTION
## Summary
- remove layout auto-detect and cover letter upload
- add centered and sidebar resume templates with accompanying CSS
- redesign index page with left-side controls, clear JD button, template info box, and SEO metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba029253c083299e67d05689bebd0c