### PR TITLE
Prevent injecting job-desc data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Notes:
 - We do NOT store your documents. Server logs exclude document text.
 - 20MB upload limit; supported: PDF, DOCX, TXT.
 - API is rate-limited (10 req/min/IP).
+- Generated resumes only include skills, titles, and locations that appear in your uploaded resume.


### PR DESCRIPTION
## Summary
- Tell the LLM to avoid inventing skills, title, or location from the job description
- Filter generated resume data to drop skills or header info not found in the uploaded resume
- Document that resumes only include details present in the uploaded file

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba227d23888329a584f096de6b0160