### PR TITLE
Include education dates and grades, capitalize skills

### DIFF
--- a/components/templates/Centered.jsx
+++ b/components/templates/Centered.jsx
@@ -50,8 +50,14 @@ export default function Centered({ data = {} }) {
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
         <div className="row" key={i}>
-          <div><strong>{e.school}</strong>{e.degree ? ` — ${e.degree}` : ""}</div>
-          {(e.start || e.end) && <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>}
+          <div>
+            <strong>{e.school}</strong>
+            {e.degree ? ` — ${e.degree}` : ""}
+            {e.grade ? ` — ${e.grade}` : ""}
+          </div>
+          {(e.start || e.end) && (
+            <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>
+          )}
         </div>
       ))}
     </div>

--- a/components/templates/Classic.jsx
+++ b/components/templates/Classic.jsx
@@ -50,8 +50,14 @@ export default function Classic({ data = {} }) {
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
         <div className="row" key={i}>
-          <div><strong>{e.school}</strong>{e.degree ? ` — ${e.degree}` : ""}</div>
-          {(e.start || e.end) && <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>}
+          <div>
+            <strong>{e.school}</strong>
+            {e.degree ? ` — ${e.degree}` : ""}
+            {e.grade ? ` — ${e.grade}` : ""}
+          </div>
+          {(e.start || e.end) && (
+            <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>
+          )}
         </div>
       ))}
     </div>

--- a/components/templates/Sidebar.jsx
+++ b/components/templates/Sidebar.jsx
@@ -30,14 +30,19 @@ export default function Sidebar({ data = {} }) {
         {edu.length > 0 && (
           <>
             <h2>Education</h2>
-            {edu.map((e, i) => (
-              <div key={i}>
-                <strong>{e.school}</strong>
-                <div className="muted">
-                  {[e.degree, e.start && fmt(e.start), e.end && fmt(e.end)].filter(Boolean).join(" • ")}
+            {edu.map((e, i) => {
+              const dateRange = [e.start && fmt(e.start), e.end && fmt(e.end)]
+                .filter(Boolean)
+                .join(" – ");
+              return (
+                <div key={i}>
+                  <strong>{e.school}</strong>
+                  <div className="muted">
+                    {[e.degree, e.grade, dateRange].filter(Boolean).join(" • ")}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </>
         )}
       </aside>

--- a/components/templates/TwoCol.jsx
+++ b/components/templates/TwoCol.jsx
@@ -30,14 +30,19 @@ export default function TwoCol({ data = {} }) {
         {edu.length > 0 && (
           <>
             <h2>Education</h2>
-            {edu.map((e, i) => (
-              <div key={i}>
-                <strong>{e.school}</strong>
-                <div className="muted">
-                  {[e.degree, e.start && fmt(e.start), e.end && fmt(e.end)].filter(Boolean).join(" • ")}
+            {edu.map((e, i) => {
+              const dateRange = [e.start && fmt(e.start), e.end && fmt(e.end)]
+                .filter(Boolean)
+                .join(" – ");
+              return (
+                <div key={i}>
+                  <strong>{e.school}</strong>
+                  <div className="muted">
+                    {[e.degree, e.grade, dateRange].filter(Boolean).join(" • ")}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </>
         )}
       </aside>

--- a/lib/normalizeResume.js
+++ b/lib/normalizeResume.js
@@ -2,7 +2,14 @@ export function normalizeResumeData(raw = {}) {
   const out = { ...raw };
 
   // Ensure arrays
-  out.skills = Array.isArray(out.skills) ? out.skills.map(String) : [];
+  out.skills = Array.isArray(out.skills)
+    ? out.skills
+        .map((s) => {
+          const str = String(s).trim();
+          return str ? str[0].toUpperCase() + str.slice(1) : "";
+        })
+        .filter(Boolean)
+    : [];
   out.experience = Array.isArray(out.experience) ? out.experience : [];
   out.education = Array.isArray(out.education) ? out.education : [];
   out.links = Array.isArray(out.links) ? out.links : [];
@@ -56,6 +63,17 @@ export function normalizeResumeData(raw = {}) {
       bullets: toArray(x?.bullets),
     }))
     .filter((e) => e.company || e.role || e.bullets.length);
+
+  // Education: coerce dates and keep if has any content
+  out.education = out.education
+    .map((e) => ({
+      school: String(e?.school || "").trim(),
+      degree: String(e?.degree || "").trim(),
+      start: toYmOrNull(e?.start) || "",
+      end: toYmOrNull(e?.end) || "",
+      grade: e?.grade ? String(e.grade).trim() : undefined,
+    }))
+    .filter((e) => e.school || e.degree || e.start || e.end || e.grade);
 
   // Scalar fields as strings
   ["name", "title", "email", "phone", "location", "summary"].forEach((k) => {

--- a/lib/resumeSchema.js
+++ b/lib/resumeSchema.js
@@ -13,7 +13,8 @@ export const EducationItem = z.object({
   school: z.string(),
   degree: z.string(),
   start: z.string(),
-  end: z.string()
+  end: z.string(),
+  grade: z.string().optional()
 });
 
 export const ResumeData = z.object({

--- a/pages/api/export-docx-structured.js
+++ b/pages/api/export-docx-structured.js
@@ -38,10 +38,13 @@ export default async function handler(req,res){
     if (Array.isArray(data.education) && data.education.length){
       docChildren.push(h("Education"));
       data.education.forEach(e=>{
-        docChildren.push(new Paragraph({ children:[
-          new TextRun({ text: `${e.school} — ${e.degree}`, bold:true }),
-          new TextRun({ text: `   ${e.start} – ${e.end}`, italics:true })
-        ]}));
+        const degree = [e.degree, e.grade].filter(Boolean).join(" — ");
+        const dates = [e.start, e.end].filter(Boolean).join(" – ");
+        const children = [
+          new TextRun({ text: `${e.school} — ${degree}`, bold:true })
+        ];
+        if (dates) children.push(new TextRun({ text: `   ${dates}`, italics:true }));
+        docChildren.push(new Paragraph({ children }));
       });
     }
 

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -83,6 +83,7 @@ STRICT RULES:
 - Treat ALLOWED_SKILLS as an allow-list. resumeData.skills MUST be a subset of ALLOWED_SKILLS.
 - Do NOT add tools/tech/frameworks in skills or experience if they are not in ALLOWED_SKILLS.
 - For resumeData.experience[], each item must include company, role, start, end, location?, bullets[]. Start/end dates must come from the candidate's resume and must not be fabricated. Bullets should be concise accomplishment statements reworded to align with the job description.
+- For resumeData.education[], each item must include school, degree, start, end, grade? Dates and grade must come from the candidate's resume and must not be fabricated.
 - The coverLetterText MUST NOT claim direct experience with non-allowed skills. Use phrasing like "While I haven't used X directly, I have Y which maps to X by Z."
 - Never fabricate employers, dates, credentials, or numbers. If unknown, omit. No prose outside JSON. No markdown fences.
 ALLOWED_SKILLS: ${allowedSkillsCSV}


### PR DESCRIPTION
## Summary
- Show education grades and dates across templates and DOCX export
- Capitalize skills in normalized resume data
- Document education grade in schema and generation prompts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba2b3e7868832985281f8ae1bc2225