### PR TITLE
Parse education date ranges for resume data

### DIFF
--- a/lib/normalizeResume.js
+++ b/lib/normalizeResume.js
@@ -52,6 +52,17 @@ export function normalizeResumeData(raw = {}) {
     return year && m2 ? `${year}-${String(m2).padStart(2, "0")}` : s;
   };
 
+  const fromDateRange = (v) => {
+    const s = String(v || "").trim();
+    if (!s) return { start: "", end: "" };
+    const parts = s.split(/[-–—]/).map((p) => p.trim()).filter(Boolean);
+    if (parts.length !== 2) return { start: "", end: "" };
+    return {
+      start: toYmOrNull(parts[0]) || "",
+      end: toYmOrNull(parts[1]) || "",
+    };
+  };
+
   // Experience: coerce bullets and dates; keep row if it has any useful content
   out.experience = out.experience
     .map((x) => ({
@@ -66,13 +77,16 @@ export function normalizeResumeData(raw = {}) {
 
   // Education: coerce dates and keep if has any content
   out.education = out.education
-    .map((e) => ({
-      school: String(e?.school || "").trim(),
-      degree: String(e?.degree || "").trim(),
-      start: toYmOrNull(e?.start) || "",
-      end: toYmOrNull(e?.end) || "",
-      grade: e?.grade ? String(e.grade).trim() : undefined,
-    }))
+    .map((e) => {
+      const range = fromDateRange(e?.dates || e?.date || e?.period);
+      return {
+        school: String(e?.school || "").trim(),
+        degree: String(e?.degree || "").trim(),
+        start: toYmOrNull(e?.start) || range.start,
+        end: toYmOrNull(e?.end) || range.end,
+        grade: e?.grade ? String(e.grade).trim() : undefined,
+      };
+    })
     .filter((e) => e.school || e.degree || e.start || e.end || e.grade);
 
   // Scalar fields as strings


### PR DESCRIPTION
## Summary
- parse combined `dates` or `date` fields in education entries to extract start and end
- normalize education data so date ranges render correctly in templates

## Testing
- `node --check lib/normalizeResume.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba2cfe56f08329b5ebb4f3869ca4fc