### PR TITLE
Parse education date strings while preserving grade

### DIFF
--- a/lib/normalizeResume.js
+++ b/lib/normalizeResume.js
@@ -52,6 +52,21 @@ export function normalizeResumeData(raw = {}) {
     return year && m2 ? `${year}-${String(m2).padStart(2, "0")}` : s;
   };
 
+  const extractEdu = (raw, existingGrade) => {
+    let grade = existingGrade ? String(existingGrade).trim() : undefined;
+    const s = String(raw || "").trim();
+    if (!s) return { start: "", end: "", grade };
+    const yearMatch = s.match(/(19|20)\d{2}/);
+    if (!yearMatch) return { start: "", end: "", grade: grade || s };
+    const prefix = s.slice(0, yearMatch.index).trim().replace(/[-–—]$/, "").trim();
+    const rest = s.slice(yearMatch.index).trim();
+    const parts = rest.split(/[-–—]/).map((p) => p.trim()).filter(Boolean);
+    const start = toYmOrNull(parts[0]) || "";
+    const end = toYmOrNull(parts[1]) || "";
+    if (!grade && prefix) grade = prefix;
+    return { start, end, grade };
+  };
+
   // Experience: coerce bullets and dates; keep row if it has any useful content
   out.experience = out.experience
     .map((x) => ({
@@ -66,13 +81,16 @@ export function normalizeResumeData(raw = {}) {
 
   // Education: coerce dates and keep if has any content
   out.education = out.education
-    .map((e) => ({
-      school: String(e?.school || "").trim(),
-      degree: String(e?.degree || "").trim(),
-      start: toYmOrNull(e?.start) || "",
-      end: toYmOrNull(e?.end) || "",
-      grade: e?.grade ? String(e.grade).trim() : undefined,
-    }))
+    .map((e) => {
+      const parsed = extractEdu(e?.dates || e?.date || e?.period, e?.grade);
+      return {
+        school: String(e?.school || "").trim(),
+        degree: String(e?.degree || "").trim(),
+        start: toYmOrNull(e?.start) || parsed.start,
+        end: toYmOrNull(e?.end) || parsed.end,
+        grade: parsed.grade ? String(parsed.grade).trim() : undefined,
+      };
+    })
     .filter((e) => e.school || e.degree || e.start || e.end || e.grade);
 
   // Scalar fields as strings


### PR DESCRIPTION
## Summary
- revert previous date range parser that dropped grade information
- extract start/end from education `dates` strings and retain any leading grade text
- normalize education entries so supplied dates render without losing levels or grades

## Testing
- `node --check lib/normalizeResume.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba2cfe56f08329b5ebb4f3869ca4fc