### PR TITLE
feat: add PDF export and fix DOCX handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "docx": "^9.0.3",
         "formidable": "^3.5.0",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^2.5.1",
         "mammoth": "^1.10.0",
         "next": "latest",
         "openai": "^4.0.0",
@@ -17,8 +19,16 @@
         "pdfreader": "^3.0.5",
         "react": "latest",
         "react-dom": "latest",
-        "react-to-print": "^2.15.1",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -632,6 +642,13 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -686,6 +703,27 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -711,6 +749,18 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -744,6 +794,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -808,11 +878,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -874,6 +965,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/duck": {
       "version": "0.1.12",
@@ -951,6 +1049,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.4",
@@ -1111,6 +1215,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1150,6 +1267,24 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -1550,6 +1685,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1561,6 +1703,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -1587,16 +1739,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-to-print": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.15.1.tgz",
-      "integrity": "sha512-1foogIFbCpzAVxydkhBiDfMiFYhIMphiagDOfcG4X/EcQ+fBPqJ0rby9Wv/emzY1YLkIQy/rEgOrWQT+rBKhjw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -1610,6 +1752,23 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/safe-buffer": {
@@ -1720,6 +1879,16 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1752,6 +1921,25 @@
         }
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -1781,6 +1969,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "latest",
     "react-dom": "latest",
     "zod": "^3.23.8",
-    "react-to-print": "^2.15.1",
-    "pdfreader": "^3.0.5"
+    "pdfreader": "^3.0.5",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   }
 }

--- a/pages/api/export-cover-letter-docx.js
+++ b/pages/api/export-cover-letter-docx.js
@@ -1,0 +1,20 @@
+import { Document, Packer, Paragraph, TextRun } from "docx";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+    const { coverLetter, filename = "cover_letter" } = body;
+    if (!coverLetter) return res.status(400).json({ error: "Missing coverLetter" });
+
+    const lines = String(coverLetter).split(/\n+/).map((line) => new Paragraph({ children: [new TextRun(line)] }));
+    const doc = new Document({ sections: [{ properties: {}, children: lines }] });
+    const buffer = await Packer.toBuffer(doc);
+
+    res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    res.setHeader("Content-Disposition", `attachment; filename="${String(filename).replace(/"/g, "")}.docx"`);
+    return res.send(Buffer.from(buffer));
+  } catch (e) {
+    return res.status(500).json({ error: "Export failed", detail: String(e?.message || e) });
+  }
+}

--- a/pages/api/export-docx-structured.js
+++ b/pages/api/export-docx-structured.js
@@ -1,21 +1,24 @@
 import { Document, Packer, Paragraph, TextRun, HeadingLevel } from "docx";
 
-function h(text, level=HeadingLevel.HEADING_2){ return new Paragraph({ heading: level, children: [new TextRun(text)] }); }
+function h(text, level = HeadingLevel.HEADING_2) {
+  return new Paragraph({ heading: level, children: [new TextRun(text)] });
+}
 function p(text){ return new Paragraph({ children:[new TextRun(text)] }); }
 function bullet(text){ return new Paragraph({ text, bullet: { level: 0 } }); }
 
-export default async function handler(req,res){
+export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).end();
-  try{
-    const { data, filename="resume" } = JSON.parse(req.body || "{}");
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+    const { data, filename = "resume" } = body;
     if (!data || !data.name) return res.status(400).json({ error: "Missing data" });
 
     const docChildren = [];
     // Header
-    docChildren.push(new Paragraph({ children: [new TextRun({ text: data.name, bold:true, size: 28 })] }));
+    docChildren.push(new Paragraph({ children: [new TextRun({ text: data.name, bold: true, size: 28 })] }));
     const meta = [data.title, data.location].filter(Boolean).join(" • ");
     if (meta) docChildren.push(p(meta));
-    const contacts = [data.email, data.phone, ...(data.links||[]).map(l=>l.url)].filter(Boolean).join(" · ");
+    const contacts = [data.email, data.phone, ...(data.links || []).map((l) => l.url)].filter(Boolean).join(" · ");
     if (contacts) docChildren.push(p(contacts));
 
     if (data.summary) { docChildren.push(h("Profile")); docChildren.push(p(data.summary)); }
@@ -25,26 +28,23 @@ export default async function handler(req,res){
     }
 
     docChildren.push(h("Experience"));
-    (data.experience||[]).forEach(x=>{
+    (data.experience || []).forEach((x) => {
       const heading = `${x.company} — ${x.role}`;
       const dates = `${x.start} – ${x.end || "Present"}`;
-      docChildren.push(new Paragraph({ children:[
-        new TextRun({ text: heading, bold:true }),
-        new TextRun({ text: `   ${dates}`, italics:true })
+      docChildren.push(new Paragraph({ children: [
+        new TextRun({ text: heading, bold: true }),
+        new TextRun({ text: `   ${dates}`, italics: true }),
       ]}));
-      (x.bullets||[]).forEach(b=>docChildren.push(bullet(b)));
+      (x.bullets || []).forEach((b) => docChildren.push(bullet(b)));
     });
 
-    if (Array.isArray(data.education) && data.education.length){
+    if (Array.isArray(data.education) && data.education.length) {
       docChildren.push(h("Education"));
-      data.education.forEach(e=>{
-        const degree = [e.degree, e.grade].filter(Boolean).join(" — ");
-        const dates = [e.start, e.end].filter(Boolean).join(" – ");
-        const children = [
-          new TextRun({ text: `${e.school} — ${degree}`, bold:true })
-        ];
-        if (dates) children.push(new TextRun({ text: `   ${dates}`, italics:true }));
-        docChildren.push(new Paragraph({ children }));
+      data.education.forEach((e) => {
+        docChildren.push(new Paragraph({ children: [
+          new TextRun({ text: `${e.school} — ${e.degree}`, bold: true }),
+          new TextRun({ text: `   ${e.start} – ${e.end}`, italics: true }),
+        ]}));
       });
     }
 
@@ -52,9 +52,9 @@ export default async function handler(req,res){
     const buffer = await Packer.toBuffer(doc);
 
     res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-    res.setHeader("Content-Disposition", `attachment; filename="${filename}.docx"`);
-    res.send(buffer);
-  }catch(e){
-    res.status(500).json({ error:"Export failed", detail:String(e?.message||e) });
+    res.setHeader("Content-Disposition", `attachment; filename="${String(filename).replace(/"/g, "")}.docx"`);
+    return res.send(Buffer.from(buffer));
+  } catch (e) {
+    return res.status(500).json({ error: "Export failed", detail: String(e?.message || e) });
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import Head from "next/head";
 import Classic from "../components/templates/Classic";
 import TwoCol from "../components/templates/TwoCol";
 import Centered from "../components/templates/Centered";
 import Sidebar from "../components/templates/Sidebar";
-import { useReactToPrint } from "react-to-print";
 
 const TEMPLATE_INFO = {
   classic: "Single-column, ATS-first. Clean headings, great for online parsers and conservative employers.",
@@ -21,7 +20,6 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
 
   const [template, setTemplate] = useState("classic"); // classic | twoCol | centered | sidebar
-  const [exportType, setExportType] = useState("pdf"); // pdf | docx
 
   const resumeScrollRef = useRef(null);
   const [resumePage, setResumePage] = useState(1);
@@ -71,10 +69,7 @@ export default function Home() {
   }
 
   const compRef = useRef(null);
-  const handlePrint = useReactToPrint({
-    content: () => compRef.current,
-    documentTitle: `${result?.resumeData?.name || "Resume"}`
-  });
+  const coverRef = useRef(null);
 
   async function handleSubmit(e){
     e.preventDefault();
@@ -100,19 +95,106 @@ export default function Home() {
     }
   }
 
-  async function downloadDocx() {
+  async function downloadCvDocx() {
     if (!result?.resumeData) return;
     const r = await fetch("/api/export-docx-structured", {
       method: "POST",
-      headers: { "Content-Type":"application/json" },
-      body: JSON.stringify({ data: result.resumeData, filename: `${(result.resumeData.name||"resume").replace(/\s+/g,"_")}` })
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: result.resumeData,
+        filename: `${(result.resumeData.name || "resume").replace(/\s+/g, "_")}`
+      })
     });
-    if (!r.ok) return alert("Export failed");
+    if (!r.ok) {
+      let msg = "Export failed";
+      try { const j = await r.json(); if (j?.error) msg = `Export failed: ${j.error}`; } catch {}
+      alert(msg);
+      return;
+    }
     const blob = await r.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
-    a.href = url; a.download = `${(result.resumeData.name||"resume").replace(/\s+/g,"_")}.docx`;
+    a.href = url; a.download = `${(result.resumeData.name || "resume").replace(/\s+/g, "_")}.docx`;
     document.body.appendChild(a); a.click(); URL.revokeObjectURL(url); a.remove();
+  }
+
+  async function downloadClDocx() {
+    if (!result?.coverLetter) return;
+    const r = await fetch("/api/export-cover-letter-docx", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        coverLetter: result.coverLetter,
+        filename: `${(result.resumeData?.name || "cover_letter").replace(/\s+/g, "_")}_cover_letter`
+      })
+    });
+    if (!r.ok) {
+      let msg = "Export failed";
+      try { const j = await r.json(); if (j?.error) msg = `Export failed: ${j.error}`; } catch {}
+      alert(msg);
+      return;
+    }
+    const blob = await r.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = `${(result.resumeData?.name || "cover_letter").replace(/\s+/g, "_")}_cover_letter.docx`;
+    document.body.appendChild(a); a.click(); URL.revokeObjectURL(url); a.remove();
+  }
+
+  async function elementToPdf(node, filename) {
+    const [{ jsPDF }, html2canvas] = await Promise.all([
+      import("jspdf"),
+      import("html2canvas").then(m => m.default || m)
+    ]);
+
+    const pdf = new jsPDF({ orientation: "p", unit: "pt", format: "a4" });
+    const pageW = pdf.internal.pageSize.getWidth();
+    const pageH = pdf.internal.pageSize.getHeight();
+
+    // temporarily remove preview scale so capture is 1:1
+    const scaleWrapper = node.closest(".a4-scale");
+    const prevTransform = scaleWrapper ? scaleWrapper.style.transform : null;
+    if (scaleWrapper) scaleWrapper.style.transform = "none";
+
+    const canvas = await html2canvas(node, { scale: 2, backgroundColor: "#ffffff", useCORS: true });
+
+    if (scaleWrapper) scaleWrapper.style.transform = prevTransform || "";
+
+    const canvasW = canvas.width;
+    const canvasH = canvas.height;
+    const pageCanvasH = (pageH * canvasW) / pageW; // canvas px height for one PDF page
+    let renderedH = 0;
+
+    while (renderedH < canvasH) {
+      const pageCanvas = document.createElement("canvas");
+      pageCanvas.width = canvasW;
+      const sliceH = Math.min(pageCanvasH, canvasH - renderedH);
+      pageCanvas.height = sliceH;
+      const ctx = pageCanvas.getContext("2d");
+      ctx.drawImage(canvas, 0, renderedH, canvasW, sliceH, 0, 0, canvasW, sliceH);
+      if (renderedH > 0) pdf.addPage();
+      const pdfPageH = pageH * (sliceH / pageCanvasH);
+      pdf.addImage(pageCanvas, "PNG", 0, 0, pageW, pdfPageH, undefined, "FAST");
+      renderedH += sliceH;
+    }
+
+    pdf.save(filename);
+  }
+
+  async function downloadCvPdf() {
+    if (!result?.resumeData) return;
+    if (resumeScrollRef?.current) {
+      const fname = `${(result.resumeData.name || "resume").replace(/\s+/g, "_")}_CV.pdf`;
+      await elementToPdf(resumeScrollRef.current, fname);
+    }
+  }
+
+  async function downloadClPdf() {
+    if (!result?.coverLetter) return;
+    if (coverRef?.current) {
+      const fname = `${(result.resumeData?.name || "cover_letter").replace(/\s+/g, "_")}_cover_letter.pdf`;
+      await elementToPdf(coverRef.current, fname);
+    }
   }
 
   const TemplateView = useMemo(() => {
@@ -130,11 +212,11 @@ export default function Home() {
         <title>TailorCV - AI Résumé + Cover Letter</title>
         <meta
           name="description"
-          content="Generate tailored, ATS-friendly resumes and cover letters with side-by-side and fullscreen previews plus PDF and DOCX export options."
+          content="Generate tailored, ATS-friendly resumes and cover letters with side-by-side and fullscreen previews plus independent, one-click PDF and DOCX downloads for CVs and cover letters."
         />
         <meta
           name="keywords"
-          content="AI resume, cover letter, ATS, PDF, DOCX, templates, side-by-side preview, fullscreen preview"
+          content="AI resume, cover letter, ATS, PDF download, DOCX download, CV PDF, cover letter PDF, independent downloads, templates, side-by-side preview, fullscreen preview, pixel-perfect"
         />
       </Head>
 
@@ -172,14 +254,6 @@ export default function Home() {
             </div>
 
             <div style={{display:"flex", gap:12, alignItems:"center"}}>
-              <div>
-                <label style={{display:"block", fontWeight:600, marginBottom:6}}>Export:</label>
-                <select value={exportType} onChange={e=>setExportType(e.target.value)}>
-                  <option value="pdf">PDF</option>
-                  <option value="docx">DOCX</option>
-                </select>
-              </div>
-
               <button type="submit" disabled={loading}>
                 {loading ? "Generating..." : "Generate"}
               </button>
@@ -256,7 +330,7 @@ export default function Home() {
                 <div className="a4-scale" onClick={() => setFullScreen('cover')} style={{cursor:'pointer'}}>
                   <div className="a4">
                     <div className="a4-inner">
-                      <div className="a4-scroll">
+                      <div ref={coverRef} className="a4-scroll">
                         {result?.coverLetter ? (
                           <div style={{ whiteSpace: "pre-wrap", lineHeight: 1.4 }}>
                             {result.coverLetter}
@@ -270,18 +344,22 @@ export default function Home() {
                 </div>
               </div>
 
-              <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
-                <button onClick={() => (exportType === "pdf" ? handlePrint() : downloadDocx())}>
-                  {exportType === "pdf" ? "Download PDF" : "Download DOCX"}
-                </button>
-                <button onClick={handlePrint}>Print</button>
+              <div style={{display:"flex", flexDirection:"column", gap:8, marginTop:10}}>
+                <div style={{display:"flex", gap:8}}>
+                  <button onClick={downloadCvPdf}>Download CV PDF</button>
+                  <button onClick={downloadCvDocx}>Download CV DOCX</button>
+                </div>
+                <div style={{display:"flex", gap:8}}>
+                  <button onClick={downloadClPdf}>Download Cover Letter PDF</button>
+                  <button onClick={downloadClDocx}>Download Cover Letter DOCX</button>
+                </div>
               </div>
             </>
           ) : (
             <div style={{ opacity: 0.6 }}>Your generated résumé will appear here.</div>
           )}
 
-          {/* Keep existing action buttons (Download/Print) BELOW the previews if you prefer.
+          {/* Keep action buttons BELOW the previews if you prefer.
               If you want them above, move them accordingly. */}
         </section>
       </main>


### PR DESCRIPTION
## Summary
- fix docx export by properly parsing request body
- add one-click PDF export using html2canvas and jsPDF
- expose PDF and DOCX downloads with separate buttons
- generate PDFs via full-page screenshots to avoid overlapping text
- fix PDF scaling to capture full-resolution pages and update SEO metadata
- fix PDF export PNG signature error by adding useCORS and embedding canvases directly

## Testing
- `npm i`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68ba392c95088329bb4874ed2be1cfbf