### PR TITLE
Ensure PDF export uses exact paper width

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -150,9 +150,14 @@ export default function Home() {
     // pick the paper element or fallback to node
     const paper = node.querySelector("[data-paper]") || node;
 
+    // measure the live paper width and size the offscreen shell to match
+    const liveRect = paper.getBoundingClientRect();
+    console.log("Live paper width:", liveRect.width);
+
     // clone into a clean, offscreen print container
     const shell = document.createElement("div");
     shell.className = "print-root";
+    shell.style.width = `${liveRect.width}px`;
     const clone = paper.cloneNode(true);
     shell.appendChild(clone);
     document.body.appendChild(shell);
@@ -168,9 +173,13 @@ export default function Home() {
       )
     );
 
+    // log the width of the clone for parity with the live paper
+    const cloneRect = clone.getBoundingClientRect();
+    console.log("Clone width:", cloneRect.width);
+
     try {
       const dpr = Math.min(2, window.devicePixelRatio || 1); // crisp without bloat
-      const rect = clone.getBoundingClientRect();
+      const rect = cloneRect;
 
       const canvas = await html2canvas(clone, {
         backgroundColor: "#ffffff",

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -205,9 +205,8 @@
   position: fixed;
   left: -100000px; top: 0;
   background: #fff;
-  /* optional: force exact A4-ish width for consistent layout if your paper is fluid */
-  /* width: 794px; */              /* comment out if your templates set width */
   transform: none !important;
+  /* width is set dynamically in JS to match the live paper width */
 }
 
 /* During capture: kill effects that change geometry/anti-aliasing */


### PR DESCRIPTION
## Summary
- Log live paper width and cloned width during PDF export
- Size offscreen print container dynamically to match paper width
- Note in CSS that width is set in JS for parity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba4fe112bc8329b3b588e3b45a714e