### PR TITLE
Fix PDF export to match preview

### DIFF
--- a/styles/resume.css
+++ b/styles/resume.css
@@ -26,8 +26,10 @@
 .resume {
   color: var(--ink);
   background: var(--bg);
-  font: 12.5px/1.45 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial;
-  max-width: 800px; margin: 0 auto; padding: 8px 6px;
+  font: 12.5px/1.75 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 8px 6px;
 }
 .resume h1 { font-size: 22px; margin: 0 0 2px; }
 .resume h2 { font-size: 13.5px; text-transform: uppercase; letter-spacing: .04em; margin: 16px 0 6px; }
@@ -36,7 +38,7 @@
 .resume .pill { display:inline-block; border:1px solid var(--rule); border-radius:999px; padding:.15rem .5rem; margin:.15rem .25rem .15rem 0; }
 .resume section { margin: 8px 0 10px; }
 .resume ul { margin: 6px 0 0 16px; padding: 0; }
-.resume li { margin: 2px 0; }
+.resume li { margin: 6px 0; }
 .resume a { color: var(--accent); text-decoration: none; }
 .resume .rule { border-top: 1px solid var(--rule); margin: 10px 0; }
 
@@ -89,7 +91,7 @@
   height: 100%;
   overflow-y: auto;       /* scroll within the page-height */
   -webkit-overflow-scrolling: touch;
-  padding: 24px;          /* content padding like a real page margin */
+  padding: 48px;          /* content padding like a real page margin */
 }
 
 /* Pager overlay */


### PR DESCRIPTION
## Summary
- expand `.a4-scroll` padding so PDF exports include roomy margins
- raise default resume line spacing and bullet spacing for all templates
- match cover letter preview spacing with resume styling

## Testing
- no tests or lint scripts present

------
https://chatgpt.com/codex/tasks/task_e_68ba5186ed608329a7c6b01a8289365d