### PR TITLE
Fix React-PDF font registration and PDF template mapping

### DIFF
--- a/components/pdf/CenteredPdf.jsx
+++ b/components/pdf/CenteredPdf.jsx
@@ -1,12 +1,5 @@
 import React from "react";
-import {
-  Page,
-  Text,
-  View,
-  Document,
-  StyleSheet,
-  Link,
-} from "@react-pdf/renderer";
+import { Document, Page, Text, View, StyleSheet, Link } from "@react-pdf/renderer";
 import "./registerFonts";
 
 const styles = StyleSheet.create({
@@ -18,12 +11,8 @@ const styles = StyleSheet.create({
     lineHeight: 1.4,
     fontFamily: "InterPDF",
   },
-  h1: {
-    fontFamily: "InterPDF",
-    fontSize: 20,
-    fontWeight: 700,
-    marginBottom: 6,
-  },
+  header: { alignItems: "center", textAlign: "center" },
+  h1: { fontFamily: "InterPDF", fontSize: 20, fontWeight: 700, marginBottom: 6 },
   h2: {
     fontFamily: "InterPDF",
     fontSize: 12,
@@ -34,8 +23,8 @@ const styles = StyleSheet.create({
   },
   muted: { color: "#64748b" },
   row: { flexDirection: "row", alignItems: "baseline" },
-  right: { marginLeft: "auto", color: "#64748b" }, // use this for dates
-  pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6 },
+  right: { marginLeft: "auto", color: "#64748b" },
+  pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6, justifyContent: "center" },
   pill: {
     fontFamily: "InterPDF",
     fontWeight: 500,
@@ -48,10 +37,10 @@ const styles = StyleSheet.create({
     marginBottom: 6,
     fontSize: 10,
   },
-  rule: { borderTopWidth: 1, borderTopColor: "#e2e8f0", marginVertical: 10 },
+  rule: { borderTopWidth: 1, borderTopColor: "#e2e8f0", marginVertical: 10, width: "96%" },
   ul: { marginTop: 4, marginLeft: 10 },
   li: { marginBottom: 4 },
-  linkRow: { flexDirection: "row", flexWrap: "wrap" },
+  linkRow: { flexDirection: "row", flexWrap: "wrap", justifyContent: "center" },
   linkText: { color: "#1a73e8", marginRight: 8 },
 });
 
@@ -62,9 +51,8 @@ function Header({ data }) {
     data.phone,
     ...(Array.isArray(data.links) ? data.links.map((l) => l.url) : []),
   ].filter(Boolean);
-
   return (
-    <View>
+    <View style={styles.header}>
       <Text style={styles.h1}>{data.name || "Candidate"}</Text>
       {meta ? <Text style={styles.muted}>{meta}</Text> : null}
       {contacts.length ? (
@@ -170,7 +158,7 @@ function Summary({ data }) {
   );
 }
 
-export default function ClassicPdf({ data }) {
+export default function CenteredPdf({ data }) {
   const safe = data || {};
   return (
     <Document>
@@ -184,3 +172,4 @@ export default function ClassicPdf({ data }) {
     </Document>
   );
 }
+

--- a/components/pdf/CoverLetterPdf.jsx
+++ b/components/pdf/CoverLetterPdf.jsx
@@ -3,10 +3,7 @@ import { Page, Text, Document, StyleSheet } from "@react-pdf/renderer";
 import "./registerFonts";
 
 const styles = StyleSheet.create({
-  page: {
-    paddingTop: 36, paddingBottom: 36, paddingHorizontal: 36,
-    fontSize: 11, lineHeight: 1.6, fontFamily: "InterPDF",
-  },
+  page: { fontFamily: "InterPDF", fontSize: 11, lineHeight: 1.6, padding: 48 },
   h1:   { fontFamily: "InterPDF", fontSize: 16, fontWeight: 700, marginBottom: 12 },
   para: { fontFamily: "InterPDF", fontWeight: 400, marginBottom: 10 },
   sign: { fontFamily: "InterPDF", fontWeight: 700, marginTop: 18 },
@@ -19,7 +16,7 @@ export default function CoverLetterPdf({ text }) {
     <Document>
       <Page size="A4" style={styles.page}>
         {body.split(/\n+/).map((line, i) => (
-          <Text key={i} style={{ marginBottom: 6 }}>{line}</Text>
+          <Text key={i} style={styles.para}>{line}</Text>
         ))}
       </Page>
     </Document>

--- a/components/pdf/SidebarPdf.jsx
+++ b/components/pdf/SidebarPdf.jsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import "./registerFonts";
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 36,
+    paddingBottom: 36,
+    paddingHorizontal: 36,
+    fontSize: 11,
+    lineHeight: 1.4,
+    fontFamily: "InterPDF",
+  },
+  grid: { flexDirection: "row" },
+  sidebar: { width: 180 },
+  main: {
+    flex: 1,
+    marginLeft: 18,
+    paddingLeft: 18,
+    borderLeftWidth: 1,
+    borderLeftColor: "#e2e8f0",
+  },
+  h1: { fontFamily: "InterPDF", fontSize: 20, fontWeight: 700, marginBottom: 4 },
+  h2: { fontFamily: "InterPDF", fontSize: 12, fontWeight: 600, marginTop: 14, marginBottom: 6, textTransform: "uppercase" },
+  muted: { color: "#64748b" },
+  pill: {
+    fontFamily: "InterPDF",
+    fontWeight: 500,
+    borderWidth: 1,
+    borderColor: "#e2e8f0",
+    borderRadius: 999,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginBottom: 6,
+    fontSize: 10,
+  },
+  row: { flexDirection: "row", alignItems: "baseline" },
+  ul: { marginTop: 4, marginLeft: 10 },
+  li: { marginBottom: 4 },
+});
+
+function Header({ data }) {
+  const meta = [data.title, data.location].filter(Boolean).join(" • ");
+  const contacts = [
+    data.email,
+    data.phone,
+    ...(Array.isArray(data.links) ? data.links.map((l) => l.url) : []),
+  ].filter(Boolean).join(" · ");
+  return (
+    <View>
+      <Text style={styles.h1}>{data.name || "Candidate"}</Text>
+      {meta ? <Text style={[styles.muted, { marginBottom: 8 }]}>{meta}</Text> : null}
+      {contacts ? <Text style={[styles.muted, { marginBottom: 8 }]}>{contacts}</Text> : null}
+    </View>
+  );
+}
+
+function Skills({ data }) {
+  if (!Array.isArray(data.skills) || !data.skills.length) return null;
+  return (
+    <View>
+      <Text style={[styles.h2, { marginTop: 0 }]}>Skills</Text>
+      {data.skills.map((s, i) => (
+        <Text key={i} style={styles.pill}>
+          {String(s)}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+function Education({ data }) {
+  const ed = Array.isArray(data.education) ? data.education : [];
+  if (!ed.length) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Education</Text>
+      {ed.map((e, i) => {
+        const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
+        const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
+        return (
+          <View key={i} style={{ marginBottom: 6 }}>
+            <Text style={{ fontWeight: 700 }}>{e.school}</Text>
+            {detail ? <Text style={styles.muted}>{detail}</Text> : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function Summary({ data }) {
+  if (!data.summary) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Profile</Text>
+      <Text>{String(data.summary)}</Text>
+    </View>
+  );
+}
+
+function Experience({ data }) {
+  const xp = Array.isArray(data.experience) ? data.experience : [];
+  if (!xp.length) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Experience</Text>
+      {xp.map((x, i) => {
+        const heading = [x.company, x.role].filter(Boolean).join(" — ");
+        const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
+        return (
+          <View key={i} wrap={false}>
+            <View style={styles.row}>
+              <Text style={{ fontWeight: 700 }}>{heading}</Text>
+              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
+            </View>
+            <View style={styles.ul}>
+              {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
+                <Text key={j} style={styles.li}>
+                  • {String(b)}
+                </Text>
+              ))}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function SidebarPdf({ data }) {
+  const safe = data || {};
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.grid}>
+          <View style={styles.sidebar}>
+            <Header data={safe} />
+            <Skills data={safe} />
+            <Education data={safe} />
+          </View>
+          <View style={styles.main}>
+            <Summary data={safe} />
+            <Experience data={safe} />
+          </View>
+        </View>
+      </Page>
+    </Document>
+  );
+}
+

--- a/components/pdf/TwoColPdf.jsx
+++ b/components/pdf/TwoColPdf.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import "./registerFonts";
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 36,
+    paddingBottom: 36,
+    paddingHorizontal: 36,
+    fontSize: 11,
+    lineHeight: 1.4,
+    fontFamily: "InterPDF",
+  },
+  grid: { flexDirection: "row" },
+  sidebar: { width: 180, marginRight: 18 },
+  main: { flex: 1 },
+  h1: { fontFamily: "InterPDF", fontSize: 20, fontWeight: 700, marginBottom: 4 },
+  h2: { fontFamily: "InterPDF", fontSize: 12, fontWeight: 600, marginTop: 14, marginBottom: 6, textTransform: "uppercase" },
+  muted: { color: "#64748b" },
+  pill: {
+    fontFamily: "InterPDF",
+    fontWeight: 500,
+    borderWidth: 1,
+    borderColor: "#e2e8f0",
+    borderRadius: 999,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginBottom: 6,
+    fontSize: 10,
+  },
+  row: { flexDirection: "row", alignItems: "baseline" },
+  ul: { marginTop: 4, marginLeft: 10 },
+  li: { marginBottom: 4 },
+  linkText: { color: "#1a73e8" },
+});
+
+function Header({ data }) {
+  const meta = [data.title, data.location].filter(Boolean).join(" • ");
+  const contacts = [
+    data.email,
+    data.phone,
+    ...(Array.isArray(data.links) ? data.links.map((l) => l.url) : []),
+  ].filter(Boolean).join(" · ");
+  return (
+    <View>
+      <Text style={styles.h1}>{data.name || "Candidate"}</Text>
+      {meta ? <Text style={[styles.muted, { marginBottom: 8 }]}>{meta}</Text> : null}
+      {contacts ? <Text style={[styles.muted, { marginBottom: 8 }]}>{contacts}</Text> : null}
+    </View>
+  );
+}
+
+function Skills({ data }) {
+  if (!Array.isArray(data.skills) || !data.skills.length) return null;
+  return (
+    <View>
+      <Text style={[styles.h2, { marginTop: 0 }]}>Skills</Text>
+      {data.skills.map((s, i) => (
+        <Text key={i} style={styles.pill}>
+          {String(s)}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+function Education({ data }) {
+  const ed = Array.isArray(data.education) ? data.education : [];
+  if (!ed.length) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Education</Text>
+      {ed.map((e, i) => {
+        const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
+        const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
+        return (
+          <View key={i} style={{ marginBottom: 6 }}>
+            <Text style={{ fontWeight: 700 }}>{e.school}</Text>
+            {detail ? <Text style={styles.muted}>{detail}</Text> : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function Summary({ data }) {
+  if (!data.summary) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Profile</Text>
+      <Text>{String(data.summary)}</Text>
+    </View>
+  );
+}
+
+function Experience({ data }) {
+  const xp = Array.isArray(data.experience) ? data.experience : [];
+  if (!xp.length) return null;
+  return (
+    <View>
+      <Text style={styles.h2}>Experience</Text>
+      {xp.map((x, i) => {
+        const heading = [x.company, x.role].filter(Boolean).join(" — ");
+        const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
+        return (
+          <View key={i} wrap={false}>
+            <View style={styles.row}>
+              <Text style={{ fontWeight: 700 }}>{heading}</Text>
+              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
+            </View>
+            <View style={styles.ul}>
+              {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
+                <Text key={j} style={styles.li}>
+                  • {String(b)}
+                </Text>
+              ))}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function TwoColPdf({ data }) {
+  const safe = data || {};
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.grid}>
+          <View style={styles.sidebar}>
+            <Header data={safe} />
+            <Skills data={safe} />
+            <Education data={safe} />
+          </View>
+          <View style={styles.main}>
+            <Summary data={safe} />
+            <Experience data={safe} />
+          </View>
+        </View>
+      </Page>
+    </Document>
+  );
+}
+

--- a/components/pdf/registerFonts.js
+++ b/components/pdf/registerFonts.js
@@ -1,12 +1,14 @@
 import { Font } from "@react-pdf/renderer";
 
-// Register a default (400) face so "fontWeight: 400" resolves
-Font.register({
-  family: "InterPDF",
-  src: "/fonts/Inter-Regular.ttf",      // default face
-});
+// Default face (weight 400) so fontWeight:400 resolves
+Font.register({ family: "InterPDF", src: "/fonts/Inter-Regular.ttf" });
 
-// Register other weights explicitly
+// Additional weights
 Font.register({ family: "InterPDF", src: "/fonts/Inter-Medium.ttf",   fontWeight: 500 });
 Font.register({ family: "InterPDF", src: "/fonts/Inter-SemiBold.ttf", fontWeight: 600 });
 Font.register({ family: "InterPDF", src: "/fonts/Inter-Bold.ttf",     fontWeight: 700 });
+
+if (typeof window !== "undefined") {
+  // Debug breadcrumb in DevTools
+  console.log("[pdf] InterPDF fonts registered");
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,14 +5,25 @@ import TwoCol from "../components/templates/TwoCol";
 import Centered from "../components/templates/Centered";
 import Sidebar from "../components/templates/Sidebar";
 import { pdf } from "@react-pdf/renderer";
+import "../components/pdf/registerFonts";
 import ClassicPdf from "../components/pdf/ClassicPdf";
 import CoverLetterPdf from "../components/pdf/CoverLetterPdf";
+import CenteredPdf from "../components/pdf/CenteredPdf";
+import TwoColPdf from "../components/pdf/TwoColPdf";
+import SidebarPdf from "../components/pdf/SidebarPdf";
 
 const TEMPLATE_INFO = {
   classic: "Single-column, ATS-first. Clean headings, great for online parsers and conservative employers.",
   twoCol: "Two columns with a compact sidebar. Good when you have many skills and want dense use of space.",
   centered: "Centered header with balanced sections. Reads modern while staying recruiter-friendly.",
   sidebar: "Prominent left sidebar for skills/education; main column for experience. Great for showcasing stack breadth."
+};
+
+const PdfMap = {
+  classic: ClassicPdf,
+  centered: CenteredPdf,
+  twoCol: TwoColPdf,
+  sidebar: SidebarPdf,
 };
 
 export default function Home() {
@@ -147,27 +158,40 @@ export default function Home() {
   // CV PDF via React-PDF
   async function downloadCvPdf() {
     if (!result?.resumeData) return;
-    // For now, render ClassicPdf regardless of on-screen template.
-    // (You can extend this to switch on `template` later.)
-    const doc = <ClassicPdf data={result.resumeData} />;
-    const blob = await pdf(doc).toBlob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${(result.resumeData.name || "resume").replace(/\s+/g, "_")}_CV.pdf`;
-    document.body.appendChild(a); a.click(); URL.revokeObjectURL(url); a.remove();
+    const Comp = PdfMap[template] || ClassicPdf;
+    console.log("[pdf] exporting with InterPDF weights 400/500/600/700");
+    try {
+      const blob = await pdf(<Comp data={result.resumeData} />).toBlob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${(result.resumeData.name || "resume").replace(/\s+/g, "_")}_CV.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      a.remove();
+    } catch (err) {
+      console.error("[pdf] export failed. Ensure font files exist under /public/fonts", err);
+    }
   }
 
   // Cover Letter PDF via React-PDF
   async function downloadClPdf() {
     if (!result?.coverLetter) return;
-    const doc = <CoverLetterPdf text={result.coverLetter} />;
-    const blob = await pdf(doc).toBlob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${(result?.resumeData?.name || "cover_letter").replace(/\s+/g, "_")}_cover_letter.pdf`;
-    document.body.appendChild(a); a.click(); URL.revokeObjectURL(url); a.remove();
+    console.log("[pdf] exporting with InterPDF weights 400/500/600/700");
+    try {
+      const blob = await pdf(<CoverLetterPdf text={result.coverLetter} />).toBlob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${(result?.resumeData?.name || "cover_letter").replace(/\s+/g, "_")}_cover_letter.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      a.remove();
+    } catch (err) {
+      console.error("[pdf] export failed. Ensure font files exist under /public/fonts", err);
+    }
   }
 
   const TemplateView = useMemo(() => {


### PR DESCRIPTION
## Summary
- register Inter font faces for React-PDF with debug log
- unify PDF styles on InterPDF with numeric weights and proper padding
- select PDF component by template with fallbacks and export diagnostics
- implement Centered, TwoCol, and Sidebar PDF templates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68baeea4ee908329b90bd298585c266b