### PR TITLE
Fix Inter font path references

### DIFF
--- a/components/pdf/registerFonts.js
+++ b/components/pdf/registerFonts.js
@@ -1,10 +1,10 @@
 import { Font } from "@react-pdf/renderer";
 
 // Register each Inter weight as its own family to avoid resolution issues
-Font.register({ family: "InterRegular", src: "/public/fonts/Inter-Regular.ttf" });
-Font.register({ family: "InterMedium",  src: "/public/fonts/Inter-Medium.ttf" });
-Font.register({ family: "InterSemiBold", src: "/public/fonts/Inter-SemiBold.ttf" });
-Font.register({ family: "InterBold",    src: "/public/fonts/Inter-Bold.ttf" });
+Font.register({ family: "InterRegular", src: "/fonts/Inter-Regular.ttf" });
+Font.register({ family: "InterMedium",  src: "/fonts/Inter-Medium.ttf" });
+Font.register({ family: "InterSemiBold", src: "/fonts/Inter-SemiBold.ttf" });
+Font.register({ family: "InterBold",    src: "/fonts/Inter-Bold.ttf" });
 
 if (typeof window !== "undefined") {
   // Debug breadcrumb in DevTools

--- a/pages/index.js
+++ b/pages/index.js
@@ -171,7 +171,7 @@ export default function Home() {
       URL.revokeObjectURL(url);
       a.remove();
     } catch (err) {
-      console.error("[pdf] export failed. Ensure font files exist under /public/fonts", err);
+      console.error("[pdf] export failed. Ensure font files exist under public/fonts", err);
     }
   }
 
@@ -190,7 +190,7 @@ export default function Home() {
       URL.revokeObjectURL(url);
       a.remove();
     } catch (err) {
-      console.error("[pdf] export failed. Ensure font files exist under /public/fonts", err);
+      console.error("[pdf] export failed. Ensure font files exist under public/fonts", err);
     }
   }
 

--- a/public/fonts/inter.css
+++ b/public/fonts/inter.css
@@ -25,8 +25,8 @@
 @font-face { font-family: "Inter"; font-style: italic; font-weight: 200; font-display: swap; src: url("Inter-ExtraLightItalic.woff2") format("woff2"); }
 @font-face { font-family: "Inter"; font-style: normal; font-weight: 300; font-display: swap; src: url("Inter-Light.woff2") format("woff2"); }
 @font-face { font-family: "Inter"; font-style: italic; font-weight: 300; font-display: swap; src: url("Inter-LightItalic.woff2") format("woff2"); }
-@font-face { font-family: "Inter"; font-style: normal; font-weight: 400; font-display: swap; src: url("/public/fonts/Inter-Regular.woff2") format("woff2"); }
-@font-face { font-family: "Inter"; font-style: italic; font-weight: 400; font-display: swap; src: url("/public/fonts/Inter-Italic.woff2") format("woff2"); }
+@font-face { font-family: "Inter"; font-style: normal; font-weight: 400; font-display: swap; src: url("Inter-Regular.woff2") format("woff2"); }
+@font-face { font-family: "Inter"; font-style: italic; font-weight: 400; font-display: swap; src: url("Inter-Italic.woff2") format("woff2"); }
 @font-face { font-family: "Inter"; font-style: normal; font-weight: 500; font-display: swap; src: url("Inter-Medium.woff2") format("woff2"); }
 @font-face { font-family: "Inter"; font-style: italic; font-weight: 500; font-display: swap; src: url("Inter-MediumItalic.woff2") format("woff2"); }
 @font-face { font-family: "Inter"; font-style: normal; font-weight: 600; font-display: swap; src: url("Inter-SemiBold.woff2") format("woff2"); }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -168,28 +168,28 @@ pre {
 }
 @font-face {
   font-family: "InterLocal";
-  src: url("/public/fonts/Inter-Regular.woff2") format("woff2");
+  src: url("/fonts/Inter-Regular.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: block;
 }
 @font-face {
   font-family: "InterLocal";
-  src: url("/public/fonts/Inter-Medium.woff2") format("woff2");
+  src: url("/fonts/Inter-Medium.woff2") format("woff2");
   font-weight: 500;
   font-style: normal;
   font-display: block;
 }
 @font-face {
   font-family: "InterLocal";
-  src: url("/public/fonts/Inter-SemiBold.woff2") format("woff2");
+  src: url("/fonts/Inter-SemiBold.woff2") format("woff2");
   font-weight: 600;
   font-style: normal;
   font-display: block;
 }
 @font-face {
   font-family: "InterLocal";
-  src: url("/public/fonts/Inter-Bold.woff2") format("woff2");
+  src: url("/fonts/Inter-Bold.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
   font-display: block;


### PR DESCRIPTION
## Summary
- fix Inter font registrations to point at `/fonts`
- adjust global font-face declarations for correct public path
- tidy Inter font CSS and update debug messages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb19afc5b083298163b661e158bb84