### PR TITLE
fix: specify Inter font weights in PDF templates

### DIFF
--- a/components/pdf/CenteredPdf.jsx
+++ b/components/pdf/CenteredPdf.jsx
@@ -12,9 +12,10 @@ const styles = StyleSheet.create({
     fontFamily: "InterRegular",
   },
   header: { alignItems: "center", textAlign: "center" },
-  h1: { fontFamily: "InterBold", fontSize: 20, marginBottom: 6 },
+  h1: { fontFamily: "InterBold", fontWeight: 700, fontSize: 20, marginBottom: 6 },
   h2: {
     fontFamily: "InterSemiBold",
+    fontWeight: 600,
     fontSize: 12,
     marginTop: 14,
     marginBottom: 6,
@@ -26,6 +27,7 @@ const styles = StyleSheet.create({
   pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6, justifyContent: "center" },
   pill: {
     fontFamily: "InterMedium",
+    fontWeight: 500,
     borderWidth: 1,
     borderColor: "#e2e8f0",
     borderRadius: 999,
@@ -105,7 +107,7 @@ function Experience({ data }) {
         return (
           <View key={i} wrap={false}>
             <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
             </View>
             <View style={styles.ul}>
@@ -135,7 +137,7 @@ function Education({ data }) {
         return (
           <View key={i} wrap={false} style={{ marginBottom: 4 }}>
             <Text>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>{" "}
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>{" "}
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
               {grade}
             </Text>

--- a/components/pdf/ClassicPdf.jsx
+++ b/components/pdf/ClassicPdf.jsx
@@ -20,11 +20,13 @@ const styles = StyleSheet.create({
   },
   h1: {
     fontFamily: "InterBold",
+    fontWeight: 700,
     fontSize: 20,
     marginBottom: 6,
   },
   h2: {
     fontFamily: "InterSemiBold",
+    fontWeight: 600,
     fontSize: 12,
     marginTop: 14,
     marginBottom: 6,
@@ -36,6 +38,7 @@ const styles = StyleSheet.create({
   pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6 },
   pill: {
     fontFamily: "InterMedium",
+    fontWeight: 500,
     borderWidth: 1,
     borderColor: "#e2e8f0",
     borderRadius: 999,
@@ -116,7 +119,7 @@ function Experience({ data }) {
         return (
           <View key={i} wrap={false}>
             <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
             </View>
             <View style={styles.ul}>
@@ -146,7 +149,7 @@ function Education({ data }) {
         return (
           <View key={i} wrap={false} style={{ marginBottom: 4 }}>
             <Text>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>{" "}
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>{" "}
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
               {grade}
             </Text>

--- a/components/pdf/CoverLetterPdf.jsx
+++ b/components/pdf/CoverLetterPdf.jsx
@@ -4,9 +4,9 @@ import "./registerFonts";
 
 const styles = StyleSheet.create({
   page: { fontFamily: "InterRegular", fontSize: 11, lineHeight: 1.6, padding: 48 },
-  h1:   { fontFamily: "InterBold", fontSize: 16, marginBottom: 12 },
+  h1:   { fontFamily: "InterBold", fontWeight: 700, fontSize: 16, marginBottom: 12 },
   para: { fontFamily: "InterRegular", marginBottom: 10 },
-  sign: { fontFamily: "InterBold", marginTop: 18 },
+  sign: { fontFamily: "InterBold", fontWeight: 700, marginTop: 18 },
 });
 
 

--- a/components/pdf/SidebarPdf.jsx
+++ b/components/pdf/SidebarPdf.jsx
@@ -20,11 +20,19 @@ const styles = StyleSheet.create({
     borderLeftWidth: 1,
     borderLeftColor: "#e2e8f0",
   },
-  h1: { fontFamily: "InterBold", fontSize: 20, marginBottom: 4 },
-  h2: { fontFamily: "InterSemiBold", fontSize: 12, marginTop: 14, marginBottom: 6, textTransform: "uppercase" },
+  h1: { fontFamily: "InterBold", fontWeight: 700, fontSize: 20, marginBottom: 4 },
+  h2: {
+    fontFamily: "InterSemiBold",
+    fontWeight: 600,
+    fontSize: 12,
+    marginTop: 14,
+    marginBottom: 6,
+    textTransform: "uppercase",
+  },
   muted: { color: "#64748b" },
   pill: {
     fontFamily: "InterMedium",
+    fontWeight: 500,
     borderWidth: 1,
     borderColor: "#e2e8f0",
     borderRadius: 999,
@@ -79,7 +87,7 @@ function Education({ data }) {
         const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
         return (
           <View key={i} style={{ marginBottom: 6 }}>
-            <Text style={{ fontFamily: "InterBold" }}>{e.school}</Text>
+            <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
           </View>
         );
@@ -110,7 +118,7 @@ function Experience({ data }) {
         return (
           <View key={i} wrap={false}>
             <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
             </View>
             <View style={styles.ul}>

--- a/components/pdf/TwoColPdf.jsx
+++ b/components/pdf/TwoColPdf.jsx
@@ -14,11 +14,19 @@ const styles = StyleSheet.create({
   grid: { flexDirection: "row" },
   sidebar: { width: 180, marginRight: 18 },
   main: { flex: 1 },
-  h1: { fontFamily: "InterBold", fontSize: 20, marginBottom: 4 },
-  h2: { fontFamily: "InterSemiBold", fontSize: 12, marginTop: 14, marginBottom: 6, textTransform: "uppercase" },
+  h1: { fontFamily: "InterBold", fontWeight: 700, fontSize: 20, marginBottom: 4 },
+  h2: {
+    fontFamily: "InterSemiBold",
+    fontWeight: 600,
+    fontSize: 12,
+    marginTop: 14,
+    marginBottom: 6,
+    textTransform: "uppercase",
+  },
   muted: { color: "#64748b" },
   pill: {
     fontFamily: "InterMedium",
+    fontWeight: 500,
     borderWidth: 1,
     borderColor: "#e2e8f0",
     borderRadius: 999,
@@ -74,7 +82,7 @@ function Education({ data }) {
         const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
         return (
           <View key={i} style={{ marginBottom: 6 }}>
-            <Text style={{ fontFamily: "InterBold" }}>{e.school}</Text>
+            <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
           </View>
         );
@@ -105,7 +113,7 @@ function Experience({ data }) {
         return (
           <View key={i} wrap={false}>
             <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold" }}>{heading}</Text>
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
               <Text style={{ fontStyle: "italic" }}>{dates}</Text>
             </View>
             <View style={styles.ul}>


### PR DESCRIPTION
## Summary
- set explicit font weights for Inter font variants across PDF components
- ensure headings and skill pills reference the correct weights to prevent runtime font errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2d4ba4f88329930978a04a197e70