### PR TITLE
feat: add resume builder wizard and dual output generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ Quickstart:
 - `npm install`
 - Set `OPENAI_API_KEY` in your env
 - `npm run dev`
+
 Notes:
-- We do NOT store your documents. Server logs exclude document text.
+- You can upload an existing CV or build one from scratch in the in-browser wizard.
+- Uploaded files are parsed to prefill the wizard; nothing is stored on the server.
 - 20MB upload limit; supported: PDF, DOCX, TXT.
 - API is rate-limited (10 req/min/IP).
-- Generated resumes only include skills, titles, and locations that appear in your uploaded resume.
+- Generated resumes only include skills, titles, and locations that appear in your provided resume data.
 
 ## Export
-- PDF export now uses @react-pdf/renderer for vector, selectable-text PDFs.
+- PDF export uses @react-pdf/renderer for vector, selectable-text PDFs.
 - DOCX export unchanged.
 - HTML preview remains the same.

--- a/components/ResumeWizard.js
+++ b/components/ResumeWizard.js
@@ -1,0 +1,209 @@
+import { useState, useEffect } from "react";
+
+const emptyResume = {
+  name: "",
+  title: "",
+  email: "",
+  phone: "",
+  location: "",
+  summary: "",
+  links: [],
+  skills: [],
+  experience: [],
+  education: []
+};
+
+export default function ResumeWizard({ initialData, onCancel, onComplete, autosaveKey, template, onTemplateChange, templateInfo }) {
+  const [data, setData] = useState(initialData || emptyResume);
+  const [step, setStep] = useState(0);
+  const [jobDesc, setJobDesc] = useState("");
+  const steps = ["basics", "skills", "work", "education", "review"];
+
+  useEffect(() => {
+    if (autosaveKey) {
+      try {
+        localStorage.setItem(autosaveKey, JSON.stringify(data));
+      } catch {}
+    }
+  }, [data, autosaveKey]);
+
+  function update(field, value) {
+    setData((d) => ({ ...d, [field]: value }));
+  }
+
+  function next() { setStep((s) => Math.min(s + 1, steps.length - 1)); }
+  function prev() { setStep((s) => Math.max(s - 1, 0)); }
+
+  function addLink() { update("links", [...data.links, { label: "", url: "" }]); }
+  function removeLink(i) { update("links", data.links.filter((_, idx) => idx !== i)); }
+
+  function addExp() {
+    update("experience", [
+      ...data.experience,
+      { company: "", role: "", start: "", end: "", location: "", bullets: [] }
+    ]);
+  }
+  function removeExp(i) { update("experience", data.experience.filter((_, idx) => idx !== i)); }
+
+  function addEdu() {
+    update("education", [
+      ...data.education,
+      { school: "", degree: "", start: "", end: "", grade: "" }
+    ]);
+  }
+  function removeEdu(i) { update("education", data.education.filter((_, idx) => idx !== i)); }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    onComplete && onComplete(data, jobDesc);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "grid", gap: 16 }}>
+      {step === 0 && (
+        <div style={{ display: "grid", gap: 8 }}>
+          <h2>Basics</h2>
+          <input placeholder="Name" value={data.name} onChange={e => update("name", e.target.value)} required />
+          <input placeholder="Title" value={data.title} onChange={e => update("title", e.target.value)} />
+          <input placeholder="Email" type="email" value={data.email} onChange={e => update("email", e.target.value)} required />
+          <input placeholder="Phone" value={data.phone} onChange={e => update("phone", e.target.value)} />
+          <input placeholder="Location" value={data.location} onChange={e => update("location", e.target.value)} />
+          <textarea placeholder="Summary" rows={4} value={data.summary} onChange={e => update("summary", e.target.value)} />
+          <div>
+            <div style={{ fontWeight: 600, marginBottom: 4 }}>Links</div>
+            {data.links.map((l, i) => (
+              <div key={i} style={{ display: "flex", gap: 4, marginBottom: 4 }}>
+                <input placeholder="Label" value={l.label} onChange={e => {
+                  const arr = [...data.links];
+                  arr[i] = { ...arr[i], label: e.target.value };
+                  update("links", arr);
+                }} />
+                <input placeholder="URL" value={l.url} onChange={e => {
+                  const arr = [...data.links];
+                  arr[i] = { ...arr[i], url: e.target.value };
+                  update("links", arr);
+                }} />
+                <button type="button" onClick={() => removeLink(i)}>✕</button>
+              </div>
+            ))}
+            <button type="button" onClick={addLink}>Add link</button>
+          </div>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div style={{ display: "grid", gap: 8 }}>
+          <h2>Skills</h2>
+          <textarea
+            rows={6}
+            value={data.skills.join("\n")}
+            onChange={e => update("skills", e.target.value.split(/\n+/).map(s => s.trim()).filter(Boolean))}
+            placeholder="One skill per line"
+          />
+        </div>
+      )}
+
+      {step === 2 && (
+        <div style={{ display: "grid", gap: 8 }}>
+          <h2>Work Experience</h2>
+          {data.experience.map((exp, i) => (
+            <div key={i} style={{ border: "1px solid #ccc", padding: 8 }}>
+              <input placeholder="Company" value={exp.company} onChange={e => {
+                const arr = [...data.experience]; arr[i] = { ...arr[i], company: e.target.value }; update("experience", arr);
+              }} />
+              <input placeholder="Role" value={exp.role} onChange={e => {
+                const arr = [...data.experience]; arr[i] = { ...arr[i], role: e.target.value }; update("experience", arr);
+              }} />
+              <input placeholder="Start (YYYY-MM)" value={exp.start} onChange={e => {
+                const arr = [...data.experience]; arr[i] = { ...arr[i], start: e.target.value }; update("experience", arr);
+              }} />
+              <input placeholder="End (YYYY-MM or blank)" value={exp.end || ""} onChange={e => {
+                const arr = [...data.experience]; arr[i] = { ...arr[i], end: e.target.value }; update("experience", arr);
+              }} />
+              <input placeholder="Location" value={exp.location || ""} onChange={e => {
+                const arr = [...data.experience]; arr[i] = { ...arr[i], location: e.target.value }; update("experience", arr);
+              }} />
+              <textarea
+                placeholder="Bullets (one per line)"
+                rows={4}
+                value={(exp.bullets || []).join("\n")}
+                onChange={e => {
+                  const arr = [...data.experience];
+                  arr[i] = { ...arr[i], bullets: e.target.value.split(/\n+/).map(s => s.trim()).filter(Boolean) };
+                  update("experience", arr);
+                }}
+              />
+              <button type="button" onClick={() => removeExp(i)}>Remove</button>
+            </div>
+          ))}
+          <button type="button" onClick={addExp}>Add experience</button>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div style={{ display: "grid", gap: 8 }}>
+          <h2>Education</h2>
+          {data.education.map((edu, i) => (
+            <div key={i} style={{ border: "1px solid #ccc", padding: 8 }}>
+              <input placeholder="School" value={edu.school} onChange={e => {
+                const arr = [...data.education]; arr[i] = { ...arr[i], school: e.target.value }; update("education", arr);
+              }} />
+              <input placeholder="Degree" value={edu.degree} onChange={e => {
+                const arr = [...data.education]; arr[i] = { ...arr[i], degree: e.target.value }; update("education", arr);
+              }} />
+              <input placeholder="Start (YYYY-MM)" value={edu.start} onChange={e => {
+                const arr = [...data.education]; arr[i] = { ...arr[i], start: e.target.value }; update("education", arr);
+              }} />
+              <input placeholder="End (YYYY-MM)" value={edu.end} onChange={e => {
+                const arr = [...data.education]; arr[i] = { ...arr[i], end: e.target.value }; update("education", arr);
+              }} />
+              <input placeholder="Grade" value={edu.grade || ""} onChange={e => {
+                const arr = [...data.education]; arr[i] = { ...arr[i], grade: e.target.value }; update("education", arr);
+              }} />
+              <button type="button" onClick={() => removeEdu(i)}>Remove</button>
+            </div>
+          ))}
+          <button type="button" onClick={addEdu}>Add education</button>
+        </div>
+      )}
+
+      {step === 4 && (
+        <div style={{ display: "grid", gap: 8 }}>
+          <h2>Review</h2>
+          <pre style={{ whiteSpace: "pre-wrap", maxHeight: 300, overflow: "auto", background: "#f5f5f5", padding: 8 }}>
+            {JSON.stringify(data, null, 2)}
+          </pre>
+          <div>
+            <label style={{ display: "block", fontWeight: 600, marginBottom: 4 }}>Template:</label>
+            <select value={template} onChange={e => onTemplateChange && onTemplateChange(e.target.value)}>
+              <option value="classic">Classic (ATS)</option>
+              <option value="twoCol">Two-Column</option>
+              <option value="centered">Centered Header</option>
+              <option value="sidebar">Sidebar</option>
+            </select>
+            {templateInfo && templateInfo[template] && (
+              <div style={{ marginTop: 4, fontSize: 12, opacity: 0.8 }}>{templateInfo[template]}</div>
+            )}
+          </div>
+          <textarea
+            rows={8}
+            value={jobDesc}
+            onChange={e => setJobDesc(e.target.value)}
+            placeholder="Paste job description here"
+            required
+            style={{ width: "100%" }}
+          />
+        </div>
+      )}
+
+      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8 }}>
+        {onCancel && <button type="button" onClick={onCancel}>Cancel</button>}
+        <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+          {step > 0 && <button type="button" onClick={prev}>Back</button>}
+          {step < steps.length - 1 && <button type="button" onClick={next}>Next</button>}
+          {step === steps.length - 1 && <button type="submit">Generate</button>}
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/pages/api/parse-resume.js
+++ b/pages/api/parse-resume.js
@@ -1,0 +1,66 @@
+import os from "os";
+import fs from "fs";
+import formidable from "formidable";
+import pdfParse from "pdf-parse";
+import mammoth from "mammoth";
+import OpenAI from "openai";
+import { normalizeResumeData } from "../../lib/normalizeResume";
+
+export const config = { api: { bodyParser: false } };
+
+function firstFile(f){ return Array.isArray(f) ? f[0] : f; }
+
+async function extractTextFromFile(file){
+  const f = firstFile(file); if (!f) return "";
+  const p = f.filepath || f.path;
+  const mime = (f.mimetype || f.type || "").toLowerCase();
+  if (!p) return "";
+  const buf = fs.readFileSync(p);
+  let text = "";
+  if (mime.includes("pdf") || p.toLowerCase().endsWith(".pdf")){
+    const r = await pdfParse(buf); text = r.text || "";
+  } else if (mime.includes("wordprocessingml") || p.toLowerCase().endsWith(".docx")){
+    const { value } = await mammoth.extractRawText({ buffer: buf }); text = value || "";
+  } else {
+    text = buf.toString("utf8");
+  }
+  try{ fs.unlinkSync(p); }catch{}
+  return text;
+}
+
+function parseForm(req){
+  const form = formidable({ multiples:false, uploadDir: os.tmpdir(), keepExtensions:true, maxFileSize: 20*1024*1024 });
+  return new Promise((resolve,reject)=>form.parse(req,(err,fields,files)=>err?reject(err):resolve({fields,files})));
+}
+
+function stripCodeFence(s=""){ const m = String(s).trim().match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i); return m ? m[1] : s; }
+function safeJSON(s){ try{ return JSON.parse(stripCodeFence(s)); } catch { return null; } }
+
+export default async function handler(req,res){
+  if (req.method !== "POST") return res.status(405).json({ error:"Method not allowed" });
+  if (!process.env.OPENAI_API_KEY) return res.status(500).json({ error:"Missing OPENAI_API_KEY" });
+  try{
+    const { files } = await parseForm(req);
+    const resumeText = await extractTextFromFile(files?.resume || files?.file);
+    if (!resumeText) return res.status(400).json({ error:"No readable file" });
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const system = `Output ONLY JSON: {"resumeData":{name,title?,email?,phone?,location?,summary?,links[],skills[],experience[],education[]}}
+Experience items must include company, role, start, end, location?, bullets[].
+Education items must include school, degree, start, end, grade?.
+Use ONLY details present in RESUME_TEXT. Do not fabricate.`;
+    const user = `RESUME_TEXT:\n${resumeText}`;
+    const resp = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      temperature: 0,
+      response_format: { type: "json_object" },
+      messages: [{ role:"system", content: system }, { role:"user", content: user }]
+    });
+    const json = safeJSON(resp.choices?.[0]?.message?.content || "");
+    if (!json) return res.status(502).json({ error:"Bad model output" });
+    const rd = normalizeResumeData(json.resumeData || json);
+    return res.status(200).json({ resumeData: rd });
+  }catch(err){
+    console.error(err);
+    return res.status(500).json({ error:"Server error", detail:String(err?.message||err) });
+  }
+}


### PR DESCRIPTION
## Summary
- add multi-step resume builder wizard with template and job description review
- parse uploaded resumes into structured data and support generating from JSON
- wire landing flow to upload or build resumes before generating tailored CV and cover letter

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb62b454a88329a6d987cf25492b0b