### PR TITLE
feat: separate job description input for generation

### DIFF
--- a/components/ResumeWizard.js
+++ b/components/ResumeWizard.js
@@ -16,8 +16,7 @@ const emptyResume = {
 export default function ResumeWizard({ initialData, onCancel, onComplete, autosaveKey, template, onTemplateChange, templateInfo }) {
   const [data, setData] = useState(initialData || emptyResume);
   const [step, setStep] = useState(0);
-  const [jobDesc, setJobDesc] = useState("");
-  const steps = ["basics", "skills", "work", "education", "review"];
+  const steps = ["basics", "skills", "work", "education", "template"];
 
   useEffect(() => {
     if (autosaveKey) {
@@ -55,7 +54,7 @@ export default function ResumeWizard({ initialData, onCancel, onComplete, autosa
 
   function handleSubmit(e) {
     e.preventDefault();
-    onComplete && onComplete(data, jobDesc);
+    onComplete && onComplete(data);
   }
 
   return (
@@ -169,10 +168,7 @@ export default function ResumeWizard({ initialData, onCancel, onComplete, autosa
 
       {step === 4 && (
         <div style={{ display: "grid", gap: 8 }}>
-          <h2>Review</h2>
-          <pre style={{ whiteSpace: "pre-wrap", maxHeight: 300, overflow: "auto", background: "#f5f5f5", padding: 8 }}>
-            {JSON.stringify(data, null, 2)}
-          </pre>
+          <h2>Finalize</h2>
           <div>
             <label style={{ display: "block", fontWeight: 600, marginBottom: 4 }}>Template:</label>
             <select value={template} onChange={e => onTemplateChange && onTemplateChange(e.target.value)}>
@@ -185,14 +181,6 @@ export default function ResumeWizard({ initialData, onCancel, onComplete, autosa
               <div style={{ marginTop: 4, fontSize: 12, opacity: 0.8 }}>{templateInfo[template]}</div>
             )}
           </div>
-          <textarea
-            rows={8}
-            value={jobDesc}
-            onChange={e => setJobDesc(e.target.value)}
-            placeholder="Paste job description here"
-            required
-            style={{ width: "100%" }}
-          />
         </div>
       )}
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,7 @@ export default function MyApp({ Component, pageProps }) {
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <meta
           name="description"
-          content="TailorCV generates ATS-friendly resumes and cover letters with side-by-side and fullscreen previews plus customizable templates."
+          content="TailorCV generates ATS-friendly resumes and cover letters tailored to any job description, with side-by-side and fullscreen previews plus customizable templates."
         />
         <link
           rel="preload"

--- a/pages/index.js
+++ b/pages/index.js
@@ -38,6 +38,8 @@ export default function Home() {
   const [showWizard, setShowWizard] = useState(false);
   const [wizardData, setWizardData] = useState(null);
   const [isScratch, setIsScratch] = useState(false);
+  const [resumeData, setResumeData] = useState(null);
+  const [jobDesc, setJobDesc] = useState("");
 
   const resumeScrollRef = useRef(null);
   const [resumePage, setResumePage] = useState(1);
@@ -121,8 +123,19 @@ export default function Home() {
     setIsScratch(true);
   }
 
-  function handleWizardComplete(data, jobDesc){
-    generateFromData(data, jobDesc);
+  function handleWizardComplete(data){
+    setResumeData(data);
+    setShowWizard(false);
+    setResult(null);
+  }
+
+  function startOver(){
+    setResumeData(null);
+    setResult(null);
+    setJobDesc("");
+    setShowWizard(false);
+    setWizardData(null);
+    setIsScratch(false);
   }
 
   async function generateFromData(resumeData, jobDesc){
@@ -246,11 +259,11 @@ export default function Home() {
         <title>TailorCV - Build or Upload a Résumé</title>
         <meta
           name="description"
-          content="Upload a CV or build one from scratch in a guided wizard, then generate a tailored, ATS-friendly resume and matching cover letter with quick PDF and DOCX downloads."
+          content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly resumes and matching cover letters with quick PDF and DOCX downloads."
         />
         <meta
           name="keywords"
-          content="AI resume builder, cover letter generator, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, side-by-side preview, fullscreen preview"
+          content="AI resume builder, cover letter generator, job description tailoring, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, side-by-side preview, fullscreen preview"
         />
       </Head>
 
@@ -260,7 +273,7 @@ export default function Home() {
         <section style={{display:"grid", gap:12, alignContent:"start"}}>
           <h1 style={{fontSize:24, marginBottom:4}}>AI Résumé + Cover Letter</h1>
 
-          {!showWizard && !result && (
+          {!showWizard && (
             <div style={{display:"grid", gap:12}}>
               <input type="file" accept=".pdf,.docx,.txt" ref={fileInputRef} style={{display:"none"}} onChange={handleFileInput} />
               <button type="button" onClick={()=>fileInputRef.current?.click()}>Upload CV</button>
@@ -268,7 +281,7 @@ export default function Home() {
             </div>
           )}
 
-          {showWizard && !result && (
+          {showWizard && (
             <ResumeWizard
               initialData={wizardData}
               onCancel={()=>setShowWizard(false)}
@@ -280,9 +293,24 @@ export default function Home() {
             />
           )}
 
-          {result && (
+          {!showWizard && resumeData && (
             <div style={{display:"grid", gap:8}}>
-              <button type="button" onClick={()=>{ setResult(null); setShowWizard(false); }}>Start over</button>
+              <textarea
+                rows={8}
+                value={jobDesc}
+                onChange={e => setJobDesc(e.target.value)}
+                placeholder="Paste job description here"
+              />
+              <div style={{display:"flex", gap:8}}>
+                <button type="button" onClick={()=>generateFromData(resumeData, jobDesc)}>Generate</button>
+                <button type="button" onClick={()=>setJobDesc("")}>Clear JD</button>
+              </div>
+            </div>
+          )}
+
+          { (resumeData || result) && !showWizard && (
+            <div style={{display:"grid", gap:8}}>
+              <button type="button" onClick={startOver}>Start over</button>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- hide raw resume JSON from wizard and finalize only with template selection
- let users paste job descriptions outside the wizard and regenerate using existing resume data
- improve meta descriptions and keywords to mention job description tailoring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb67ead38c83299ab2c01ad57d4af2