### PR TITLE
Revamp resume wizard UI with chip-based inputs and card fieldsets

### DIFF
--- a/components/wizard/EducationCard.jsx
+++ b/components/wizard/EducationCard.jsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export default function EducationCard({ value, onChange, onRemove, onDuplicate, index }) {
+  const [bulletInput, setBulletInput] = useState('');
+
+  function updateField(field, val) {
+    onChange({ ...value, [field]: val });
+  }
+
+  function addBullet() {
+    const t = bulletInput.trim();
+    if (!t) return;
+    const bullets = [...(value.bullets || []), t];
+    onChange({ ...value, bullets });
+    setBulletInput('');
+  }
+
+  function removeBullet(i) {
+    const bullets = (value.bullets || []).filter((_, idx) => idx !== i);
+    onChange({ ...value, bullets });
+  }
+
+  return (
+    <motion.div layout initial={{ opacity:0, scale:0.95 }} animate={{ opacity:1, scale:1 }} exit={{ opacity:0, scale:0.95 }}
+      className="bg-white dark:bg-zinc-900 border rounded-2xl shadow-sm p-4 sm:p-6 space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">School*</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.school}
+            onChange={e => updateField('school', e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">Degree</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.degree || ''}
+            onChange={e => updateField('degree', e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">Grade</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.grade || ''}
+            onChange={e => updateField('grade', e.target.value)}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-zinc-600">Start</label>
+            <input
+              type="month"
+              className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+              value={value.start}
+              onChange={e => updateField('start', e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-zinc-600">End</label>
+            <input
+              type="month"
+              disabled={value.present}
+              className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent disabled:opacity-50"
+              value={value.end || ''}
+              onChange={e => updateField('end', e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <input id={`edu-present-${index}`} type="checkbox" checked={value.present || false} onChange={e => updateField('present', e.target.checked)} />
+          <label htmlFor={`edu-present-${index}`} className="text-sm">Present</label>
+        </div>
+      </div>
+
+      <div className="pt-2 border-t border-zinc-200 dark:border-zinc-700 space-y-2">
+        <div className="text-xs font-medium text-zinc-500">Highlights</div>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 h-11 rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={bulletInput}
+            onChange={e=>setBulletInput(e.target.value)}
+            onKeyDown={e=>{ if(e.key==='Enter'){ e.preventDefault(); addBullet(); } }}
+            aria-label="Add highlight"
+          />
+          <button type="button" onClick={addBullet} className="px-3 h-11 rounded-xl bg-teal-600 text-white disabled:opacity-50" disabled={!bulletInput.trim()}>+ Add</button>
+        </div>
+        <ul className="space-y-2">
+          <AnimatePresence>
+            {(value.bullets || []).map((b, i) => (
+              <motion.li key={i} initial={{opacity:0, scale:0.95}} animate={{opacity:1, scale:1}} exit={{opacity:0, scale:0.95}} className="flex items-start gap-2">
+                <span className="flex-1 text-sm">{b}</span>
+                <button type="button" onClick={()=>removeBullet(i)} aria-label="Remove highlight" className="text-zinc-500 hover:text-zinc-800">×</button>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </ul>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-700">
+        {onDuplicate && <button type="button" onClick={onDuplicate} className="text-sm text-teal-600">Duplicate</button>}
+        {onRemove && <button type="button" onClick={onRemove} className="text-sm text-red-600">Remove</button>}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/wizard/ExperienceCard.jsx
+++ b/components/wizard/ExperienceCard.jsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export default function ExperienceCard({ value, onChange, onRemove, onDuplicate, index }) {
+  const [bulletInput, setBulletInput] = useState('');
+
+  function updateField(field, val) {
+    onChange({ ...value, [field]: val });
+  }
+
+  function addBullet() {
+    const t = bulletInput.trim();
+    if (!t) return;
+    const bullets = [...(value.bullets || []), t];
+    onChange({ ...value, bullets });
+    setBulletInput('');
+  }
+
+  function removeBullet(i) {
+    const bullets = (value.bullets || []).filter((_, idx) => idx !== i);
+    onChange({ ...value, bullets });
+  }
+
+  return (
+    <motion.div layout initial={{ opacity:0, scale:0.95 }} animate={{ opacity:1, scale:1 }} exit={{ opacity:0, scale:0.95 }}
+      className="bg-white dark:bg-zinc-900 border rounded-2xl shadow-sm p-4 sm:p-6 space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">Company*</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.company}
+            onChange={e => updateField('company', e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">Role*</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.role}
+            onChange={e => updateField('role', e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-zinc-600">Location</label>
+          <input
+            className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={value.location || ''}
+            onChange={e => updateField('location', e.target.value)}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-zinc-600">Start</label>
+            <input
+              type="month"
+              className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+              value={value.start}
+              onChange={e => updateField('start', e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-zinc-600">End</label>
+            <input
+              type="month"
+              disabled={value.present}
+              className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent disabled:opacity-50"
+              value={value.end || ''}
+              onChange={e => updateField('end', e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <input id={`exp-present-${index}`} type="checkbox" checked={value.present || false} onChange={e => updateField('present', e.target.checked)} />
+          <label htmlFor={`exp-present-${index}`} className="text-sm">Present</label>
+        </div>
+      </div>
+
+      <div className="pt-2 border-t border-zinc-200 dark:border-zinc-700 space-y-2">
+        <div className="text-xs font-medium text-zinc-500">Bullets</div>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 h-11 rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+            value={bulletInput}
+            onChange={e=>setBulletInput(e.target.value)}
+            onKeyDown={e=>{ if(e.key==='Enter'){ e.preventDefault(); addBullet(); } }}
+            aria-label="Add bullet"
+          />
+          <button type="button" onClick={addBullet} className="px-3 h-11 rounded-xl bg-teal-600 text-white disabled:opacity-50" disabled={!bulletInput.trim()}>+ Add bullet</button>
+        </div>
+        <ul className="space-y-2">
+          <AnimatePresence>
+            {(value.bullets || []).map((b, i) => (
+              <motion.li key={i} initial={{opacity:0, scale:0.95}} animate={{opacity:1, scale:1}} exit={{opacity:0, scale:0.95}} className="flex items-start gap-2">
+                <span className="flex-1 text-sm">{b}</span>
+                <button type="button" onClick={()=>removeBullet(i)} aria-label="Remove bullet" className="text-zinc-500 hover:text-zinc-800">×</button>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </ul>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-700">
+        {onDuplicate && <button type="button" onClick={onDuplicate} className="text-sm text-teal-600">Duplicate role</button>}
+        {onRemove && <button type="button" onClick={onRemove} className="text-sm text-red-600">Remove role</button>}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/wizard/SkillsInput.jsx
+++ b/components/wizard/SkillsInput.jsx
@@ -1,0 +1,113 @@
+import { useState, useRef } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+const COMMON_SKILLS = [
+  'JavaScript', 'TypeScript', 'React', 'Node.js', 'Python', 'SQL', 'Docker', 'AWS', 'CSS', 'HTML'
+];
+
+export default function SkillsInput({ value = [], onChange }) {
+  const [input, setInput] = useState('');
+  const inputRef = useRef(null);
+
+  function commit(raw) {
+    if (!raw) return;
+    const parts = raw.split(/[,\n]+/).map(s => s.trim()).filter(Boolean);
+    const existing = new Set(value.map(v => v.toLowerCase()));
+    const next = [...value];
+    for (const p of parts) {
+      const key = p.toLowerCase();
+      if (!existing.has(key)) {
+        existing.add(key);
+        next.push(p);
+      }
+    }
+    if (next.length !== value.length) onChange(next);
+  }
+
+  function handleAdd() {
+    commit(input);
+    setInput('');
+    inputRef.current?.focus();
+  }
+
+  function handleKey(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  }
+
+  function handlePaste(e) {
+    const text = e.clipboardData.getData('text');
+    if (text && /[\n,]/.test(text)) {
+      e.preventDefault();
+      commit(text);
+      setInput('');
+    }
+  }
+
+  function remove(skill) {
+    onChange(value.filter(s => s !== skill));
+  }
+
+  const suggestions = input
+    ? COMMON_SKILLS.filter(s => s.toLowerCase().includes(input.toLowerCase()) && !value.includes(s)).slice(0,5)
+    : [];
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          className="flex-1 h-11 rounded-xl border border-zinc-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
+          value={input}
+          onChange={e=>setInput(e.target.value)}
+          onKeyDown={handleKey}
+          onPaste={handlePaste}
+          aria-label="Add skill"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="px-4 h-11 rounded-xl bg-teal-600 text-white disabled:opacity-50"
+          disabled={!input.trim()}
+        >+ Add</button>
+      </div>
+      {!!suggestions.length && (
+        <div className="flex gap-2 flex-wrap text-sm">
+          {suggestions.map(s => (
+            <button key={s} type="button" onClick={()=>{commit(s); setInput('');}} className="px-2 py-1 rounded-md border border-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700" aria-label={`Add ${s}`}>
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2 flex-wrap">
+        <AnimatePresence>
+          {value.map(skill => (
+            <motion.span
+              key={skill}
+              layout
+              initial={{ scale:0.8, opacity:0 }}
+              animate={{ scale:1, opacity:1 }}
+              exit={{ scale:0.8, opacity:0 }}
+              transition={{ type:'spring', duration:0.2 }}
+              className="flex items-center gap-1 px-3 py-1.5 text-sm rounded-full border border-zinc-300 bg-zinc-100 dark:bg-zinc-800"
+            >
+              <span>{skill}</span>
+              <button
+                type="button"
+                className="focus:outline-none"
+                onClick={()=>remove(skill)}
+                aria-label={`Remove ${skill}`}
+                onKeyDown={(e)=>{ if(e.key==='Backspace' || e.key==='Delete'){ e.preventDefault(); remove(skill); } }}
+              >
+                ×
+              </button>
+            </motion.span>
+          ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "tailorcv",
       "version": "1.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.2",
         "@react-pdf/renderer": "^3.4.0",
         "docx": "^9.0.3",
         "formidable": "^3.5.0",
+        "framer-motion": "^11.0.12",
         "google-fonts": "^1.0.0",
         "mammoth": "^1.10.0",
         "next": "latest",
@@ -19,6 +21,7 @@
         "pdfreader": "^3.0.5",
         "react": "latest",
         "react-dom": "latest",
+        "react-hook-form": "^7.51.3",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -57,6 +60,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1850,6 +1862,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2397,6 +2436,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3048,6 +3102,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "pdfreader": "^3.0.5",
     "react": "latest",
     "react-dom": "latest",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "react-hook-form": "^7.51.3",
+    "@hookform/resolvers": "^3.3.2",
+    "framer-motion": "^11.0.12"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
## Summary
- replace wizard form with responsive, validated steps using react-hook-form and zod
- add chip-based skills input with suggestion popover and animations
- introduce animated card fieldsets for work experience and education
- add sticky footer navigation with validation messaging
- install react-hook-form and framer-motion dependencies

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb76fdb708832983eb72927fd59a4a