### PR TITLE
feat: add cover letter tone and ATS optimizations

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,7 @@ export default function MyApp({ Component, pageProps }) {
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <meta
           name="description"
-          content="TailorCV generates ATS-friendly resumes and cover letters tailored to any job description, with side-by-side and fullscreen previews plus customizable templates."
+          content="TailorCV generates ATS-friendly resumes and cover letters tailored to any job description, with selectable tone, side-by-side and fullscreen previews, plus customizable templates."
         />
         <link
           rel="preload"

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -71,6 +71,7 @@ async function coreHandler(req, res){
     const resumeText = resumeData ? "" : await extractTextFromFile(files?.resume);
     const coverText  = await extractTextFromFile(files?.coverLetter);
     const jobDesc    = Array.isArray(fields?.jobDesc) ? fields.jobDesc[0] : (fields?.jobDesc || "");
+    const tone       = Array.isArray(fields?.tone) ? fields.tone[0] : (fields?.tone || "professional");
 
     if (!resumeData && !resumeText) return res.status(400).json({ error:"No readable resume", code:"E_NO_RESUME" });
     if (!jobDesc || jobDesc.trim().length < 30) return res.status(400).json({ error:"Job description too short", code:"E_BAD_INPUT" });
@@ -95,6 +96,8 @@ STRICT RULES:
 - For resumeData.experience[], each item must include company, role, start, end, location?, bullets[]. Start/end dates must come from the candidate's resume and must not be fabricated. Bullets should be concise accomplishment statements reworded to align with the job description.
 - For resumeData.education[], each item must include school, degree, start, end, grade? Dates and grade must come from the candidate's resume and must not be fabricated.
 - The coverLetterText MUST NOT claim direct experience with non-allowed skills. Use phrasing like "While I haven't used X directly, I have Y which maps to X by Z."
+- The coverLetterText must adopt a ${tone} tone.
+- The resume must be ATS-optimized: use plain formatting, concise bullet points beginning with strong action verbs, and integrate relevant keywords from the job description where applicable. Avoid tables or images.
 - Never fabricate employers, dates, credentials, or numbers. If unknown, omit. No prose outside JSON. No markdown fences.
 ALLOWED_SKILLS: ${allowedSkillsCSV}
 `.trim();
@@ -102,6 +105,9 @@ ALLOWED_SKILLS: ${allowedSkillsCSV}
     const resumePayload = resumeData ? JSON.stringify(resumeData) : resumeText;
     const user = `
 Generate JSON for a tailored cover letter and a revised resume (ATS-friendly).
+
+Cover Letter Tone:
+${tone}
 
 Job Description:
 ${jobDesc}

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,6 +40,7 @@ export default function Home() {
   const [isScratch, setIsScratch] = useState(false);
   const [resumeData, setResumeData] = useState(null);
   const [jobDesc, setJobDesc] = useState("");
+  const [coverTone, setCoverTone] = useState("professional");
   const [phase, setPhase] = useState("entry"); // entry | target | results
 
   const resumeScrollRef = useRef(null);
@@ -135,6 +136,7 @@ export default function Home() {
     setResumeData(null);
     setResult(null);
     setJobDesc("");
+    setCoverTone("professional");
     setShowWizard(false);
     setWizardData(null);
     setIsScratch(false);
@@ -145,11 +147,12 @@ export default function Home() {
   function newJob(){
     setResult(null);
     setJobDesc("");
+    setCoverTone("professional");
     setError("");
     setPhase("target");
   }
 
-  async function generateFromData(resumeData, jobDesc){
+  async function generateFromData(resumeData, jobDesc, coverTone){
     setError(""); setResult(null);
     if(!jobDesc.trim()) return setError("Please paste a job description.");
     try{
@@ -157,6 +160,7 @@ export default function Home() {
       const fd = new FormData();
       fd.append("resumeData", JSON.stringify(resumeData));
       fd.append("jobDesc", jobDesc);
+      fd.append("tone", coverTone);
       const res = await fetch("/api/generate", { method:"POST", body: fd });
       const data = await res.json();
       if(!res.ok) throw new Error(data?.error || "Generation failed");
@@ -271,11 +275,11 @@ export default function Home() {
         <title>TailorCV - Build or Upload a Résumé</title>
         <meta
           name="description"
-          content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters with quick PDF and DOCX downloads. Reuse your CV for multiple job descriptions or upload a new one anytime, complete with live A4 resume and cover letter previews."
+          content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters with selectable tone and quick PDF and DOCX downloads. Reuse your CV for multiple job descriptions or upload a new one anytime, complete with live A4 resume and cover letter previews."
         />
         <meta
           name="keywords"
-            content="AI resume builder, cover letter generator, job description tailoring, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview"
+            content="AI resume builder, cover letter generator, job description tailoring, cover letter tone selection, tone selector, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview"
           />
       </Head>
       <main className="tc-container tc-page">
@@ -312,9 +316,21 @@ export default function Home() {
               onChange={e => setJobDesc(e.target.value)}
               placeholder="Paste the job description"
             />
+            <label className="block">
+              <span className="text-sm">Cover Letter Tone</span>
+              <select
+                className="tc-input mt-1"
+                value={coverTone}
+                onChange={e => setCoverTone(e.target.value)}
+              >
+                <option value="professional">Professional</option>
+                <option value="friendly">Friendly</option>
+                <option value="enthusiastic">Enthusiastic</option>
+              </select>
+            </label>
             <div className="tc-sticky flex justify-between">
               <button type="button" className="tc-btn-quiet" onClick={()=>setJobDesc('')}>Clear JD</button>
-              <button type="button" className="tc-btn-primary" onClick={()=>generateFromData(resumeData, jobDesc)}>Generate CV + Cover Letter</button>
+              <button type="button" className="tc-btn-primary" onClick={()=>generateFromData(resumeData, jobDesc, coverTone)}>Generate CV + Cover Letter</button>
             </div>
           </section>
         )}


### PR DESCRIPTION
## Summary
- let users choose the cover letter tone when generating
- instruct resume generation to enforce ATS-friendly phrasing and support the chosen tone
- update SEO metadata to reflect tone customization

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb7a4246a88329b74ce748c4bc0ccc