### PR TITLE
Align resume dates with roles and education

### DIFF
--- a/components/pdf/CenteredPdf.jsx
+++ b/components/pdf/CenteredPdf.jsx
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
   },
   muted: { color: "#64748b" },
   row: { flexDirection: "row", alignItems: "baseline" },
-  right: { marginLeft: "auto", color: "#64748b" },
+  right: { marginLeft: "auto", color: "#64748b" }, // legacy
   pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6, justifyContent: "center" },
   pill: {
     fontFamily: "InterMedium",
@@ -102,14 +102,14 @@ function Experience({ data }) {
     <View>
       <SectionTitle>Experience</SectionTitle>
       {xp.map((x, i) => {
-        const heading = [x.company, x.role].filter(Boolean).join(" — ");
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
           <View key={i} wrap={false}>
-            <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-            </View>
+            {x.company ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
+            ) : null}
+            {x.role ? <Text>{x.role}</Text> : null}
+            {dates ? <Text style={{ color: "#64748b" }}>{dates}</Text> : null}
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
                 <Text key={j} style={styles.li}>
@@ -131,16 +131,15 @@ function Education({ data }) {
     <View>
       <SectionTitle>Education</SectionTitle>
       {ed.map((e, i) => {
-        const heading = [e.school, e.degree].filter(Boolean).join(" — ");
         const dates = [e.start, e.end].filter(Boolean).join(" – ");
-        const grade = e.grade ? ` • ${e.grade}` : "";
+        const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
           <View key={i} wrap={false} style={{ marginBottom: 4 }}>
-            <Text>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>{" "}
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-              {grade}
-            </Text>
+            {e.school ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
+            ) : null}
+            {detail ? <Text>{detail}</Text> : null}
+            {dates ? <Text style={{ color: "#64748b" }}>{dates}</Text> : null}
           </View>
         );
       })}

--- a/components/pdf/ClassicPdf.jsx
+++ b/components/pdf/ClassicPdf.jsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
   },
   muted: { color: "#64748b" },
   row: { flexDirection: "row", alignItems: "baseline" },
-  right: { marginLeft: "auto", color: "#64748b" }, // use this for dates
+  right: { marginLeft: "auto", color: "#64748b" }, // legacy; no longer used for dates
   pillWrap: { flexDirection: "row", flexWrap: "wrap", marginBottom: 6 },
   pill: {
     fontFamily: "InterMedium",
@@ -114,14 +114,14 @@ function Experience({ data }) {
     <View>
       <SectionTitle>Experience</SectionTitle>
       {xp.map((x, i) => {
-        const heading = [x.company, x.role].filter(Boolean).join(" — ");
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
           <View key={i} wrap={false}>
-            <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-            </View>
+            {x.company ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
+            ) : null}
+            {x.role ? <Text>{x.role}</Text> : null}
+            {dates ? <Text style={{ color: "#64748b" }}>{dates}</Text> : null}
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
                 <Text key={j} style={styles.li}>
@@ -143,16 +143,15 @@ function Education({ data }) {
     <View>
       <SectionTitle>Education</SectionTitle>
       {ed.map((e, i) => {
-        const heading = [e.school, e.degree].filter(Boolean).join(" — ");
         const dates = [e.start, e.end].filter(Boolean).join(" – ");
-        const grade = e.grade ? ` • ${e.grade}` : "";
+        const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
           <View key={i} wrap={false} style={{ marginBottom: 4 }}>
-            <Text>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>{" "}
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-              {grade}
-            </Text>
+            {e.school ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
+            ) : null}
+            {detail ? <Text>{detail}</Text> : null}
+            {dates ? <Text style={{ color: "#64748b" }}>{dates}</Text> : null}
           </View>
         );
       })}

--- a/components/pdf/SidebarPdf.jsx
+++ b/components/pdf/SidebarPdf.jsx
@@ -84,11 +84,12 @@ function Education({ data }) {
       <Text style={styles.h2}>Education</Text>
       {ed.map((e, i) => {
         const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
-        const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
+        const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
           <View key={i} style={{ marginBottom: 6 }}>
             <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
+            {dateRange ? <Text style={styles.muted}>{dateRange}</Text> : null}
           </View>
         );
       })}
@@ -113,14 +114,14 @@ function Experience({ data }) {
     <View>
       <Text style={styles.h2}>Experience</Text>
       {xp.map((x, i) => {
-        const heading = [x.company, x.role].filter(Boolean).join(" — ");
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
           <View key={i} wrap={false}>
-            <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-            </View>
+            {x.company ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
+            ) : null}
+            {x.role ? <Text>{x.role}</Text> : null}
+            {dates ? <Text style={styles.muted}>{dates}</Text> : null}
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
                 <Text key={j} style={styles.li}>

--- a/components/pdf/TwoColPdf.jsx
+++ b/components/pdf/TwoColPdf.jsx
@@ -79,11 +79,12 @@ function Education({ data }) {
       <Text style={styles.h2}>Education</Text>
       {ed.map((e, i) => {
         const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
-        const detail = [e.degree, e.grade, dateRange].filter(Boolean).join(" • ");
+        const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
           <View key={i} style={{ marginBottom: 6 }}>
             <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
+            {dateRange ? <Text style={styles.muted}>{dateRange}</Text> : null}
           </View>
         );
       })}
@@ -108,14 +109,14 @@ function Experience({ data }) {
     <View>
       <Text style={styles.h2}>Experience</Text>
       {xp.map((x, i) => {
-        const heading = [x.company, x.role].filter(Boolean).join(" — ");
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
           <View key={i} wrap={false}>
-            <View style={styles.row}>
-              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{heading}</Text>
-              <Text style={{ fontStyle: "italic" }}>{dates}</Text>
-            </View>
+            {x.company ? (
+              <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
+            ) : null}
+            {x.role ? <Text>{x.role}</Text> : null}
+            {dates ? <Text style={styles.muted}>{dates}</Text> : null}
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
                 <Text key={j} style={styles.li}>

--- a/components/templates/Centered.jsx
+++ b/components/templates/Centered.jsx
@@ -32,13 +32,10 @@ export default function Centered({ data = {} }) {
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
         <section key={i}>
-          {(x.company || x.role || x.start || x.end) && (
-            <div className="row">
-              <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
-              {(x.start || x.end != null) && (
-                <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
-              )}
-            </div>
+          {x.company && <strong>{x.company}</strong>}
+          {x.role && <div>{x.role}</div>}
+          {(x.start || x.end != null) && (
+            <div className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</div>
           )}
           {x.location && <div className="muted">{x.location}</div>}
           {Array.isArray(x.bullets) && x.bullets.length > 0 && (
@@ -49,12 +46,11 @@ export default function Centered({ data = {} }) {
 
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
-        <div className="row" key={i}>
-          <div>
-            <strong>{e.school}</strong>
-            {e.degree ? ` — ${e.degree}` : ""}
-            {e.grade ? ` — ${e.grade}` : ""}
-          </div>
+        <div key={i}>
+          {e.school && <strong>{e.school}</strong>}
+          {(e.degree || e.grade) && (
+            <div>{[e.degree, e.grade].filter(Boolean).join(" — ")}</div>
+          )}
           {(e.start || e.end) && (
             <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>
           )}

--- a/components/templates/Classic.jsx
+++ b/components/templates/Classic.jsx
@@ -32,13 +32,10 @@ export default function Classic({ data = {} }) {
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
         <section key={i}>
-          {(x.company || x.role || x.start || x.end) && (
-            <div className="row">
-              <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
-              {(x.start || x.end != null) && (
-                <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
-              )}
-            </div>
+          {x.company && <strong>{x.company}</strong>}
+          {x.role && <div>{x.role}</div>}
+          {(x.start || x.end != null) && (
+            <div className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</div>
           )}
           {x.location && <div className="muted">{x.location}</div>}
           {Array.isArray(x.bullets) && x.bullets.length > 0 && (
@@ -49,12 +46,11 @@ export default function Classic({ data = {} }) {
 
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
-        <div className="row" key={i}>
-          <div>
-            <strong>{e.school}</strong>
-            {e.degree ? ` — ${e.degree}` : ""}
-            {e.grade ? ` — ${e.grade}` : ""}
-          </div>
+        <div key={i}>
+          {e.school && <strong>{e.school}</strong>}
+          {(e.degree || e.grade) && (
+            <div>{[e.degree, e.grade].filter(Boolean).join(" — ")}</div>
+          )}
           {(e.start || e.end) && (
             <div className="muted">{fmt(e.start)} – {fmt(e.end)}</div>
           )}

--- a/components/templates/Sidebar.jsx
+++ b/components/templates/Sidebar.jsx
@@ -34,12 +34,12 @@ export default function Sidebar({ data = {} }) {
               const dateRange = [e.start && fmt(e.start), e.end && fmt(e.end)]
                 .filter(Boolean)
                 .join(" – ");
+              const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
               return (
                 <div key={i}>
                   <strong>{e.school}</strong>
-                  <div className="muted">
-                    {[e.degree, e.grade, dateRange].filter(Boolean).join(" • ")}
-                  </div>
+                  {detail && <div>{detail}</div>}
+                  {dateRange && <div className="muted">{dateRange}</div>}
                 </div>
               );
             })}
@@ -52,13 +52,10 @@ export default function Sidebar({ data = {} }) {
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
           <section key={i}>
-            {(x.company || x.role || x.start || x.end) && (
-              <div className="row">
-                <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
-                {(x.start || x.end != null) && (
-                  <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
-                )}
-              </div>
+            {x.company && <strong>{x.company}</strong>}
+            {x.role && <div>{x.role}</div>}
+            {(x.start || x.end != null) && (
+              <div className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</div>
             )}
             {x.location && <div className="muted">{x.location}</div>}
             {Array.isArray(x.bullets) && x.bullets.length > 0 && (

--- a/components/templates/TwoCol.jsx
+++ b/components/templates/TwoCol.jsx
@@ -34,12 +34,12 @@ export default function TwoCol({ data = {} }) {
               const dateRange = [e.start && fmt(e.start), e.end && fmt(e.end)]
                 .filter(Boolean)
                 .join(" – ");
+              const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
               return (
                 <div key={i}>
                   <strong>{e.school}</strong>
-                  <div className="muted">
-                    {[e.degree, e.grade, dateRange].filter(Boolean).join(" • ")}
-                  </div>
+                  {detail && <div>{detail}</div>}
+                  {dateRange && <div className="muted">{dateRange}</div>}
                 </div>
               );
             })}
@@ -52,13 +52,10 @@ export default function TwoCol({ data = {} }) {
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
           <section key={i}>
-            {(x.company || x.role || x.start || x.end) && (
-              <div className="row">
-                <strong>{[x.company, x.role].filter(Boolean).join(" — ")}</strong>
-                {(x.start || x.end != null) && (
-                  <span className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</span>
-                )}
-              </div>
+            {x.company && <strong>{x.company}</strong>}
+            {x.role && <div>{x.role}</div>}
+            {(x.start || x.end != null) && (
+              <div className="muted">{fmt(x.start)} – {x.end == null ? "Present" : fmt(x.end)}</div>
             )}
             {x.location && <div className="muted">{x.location}</div>}
             {Array.isArray(x.bullets) && x.bullets.length > 0 && (


### PR DESCRIPTION
## Summary
- Move job date ranges beneath job titles in all preview templates
- Display education dates directly below degree information
- Include the same date layout in exported PDF templates

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb81f7a2648329b49b9c854f98cfcf