### PR TITLE
Add Modern ATS-safe two-column HTML resume template

### DIFF
--- a/components/ResumeWizard.js
+++ b/components/ResumeWizard.js
@@ -8,6 +8,7 @@ import Classic from './templates/Classic';
 import TwoCol from './templates/TwoCol';
 import Centered from './templates/Centered';
 import Sidebar from './templates/Sidebar';
+import Modern from './templates/Modern';
 import { AnimatePresence } from 'framer-motion';
 
 const emptyResume = {
@@ -175,6 +176,7 @@ export default function ResumeWizard({ initialData, onComplete, autosaveKey, tem
 
   const TemplatePreview = useMemo(() => {
     switch (template) {
+      case 'modern': return Modern;
       case 'twoCol': return TwoCol;
       case 'centered': return Centered;
       case 'sidebar': return Sidebar;
@@ -297,6 +299,7 @@ export default function ResumeWizard({ initialData, onComplete, autosaveKey, tem
                   <option value="twoCol">Two-Column</option>
                   <option value="centered">Centered Header</option>
                   <option value="sidebar">Sidebar</option>
+                  <option value="modern">Modern</option>
                 </select>
                 {templateInfo && templateInfo[template] && (
                   <p className="text-sm text-zinc-500 mt-1">{templateInfo[template]}</p>

--- a/components/templates/Modern.jsx
+++ b/components/templates/Modern.jsx
@@ -1,0 +1,115 @@
+import React from "react";
+
+/**
+ * Modern two-column HTML resume template (grid-based, ATS-safe).
+ * Expects prop: { data } with shape used by other templates:
+ * { name, title?, email, phone?, location?, links[], summary?, skills[], experience[], education[] }
+ */
+export default function Modern({ data = {} }) {
+  const {
+    name = "",
+    title = "",
+    email = "",
+    phone = "",
+    location = "",
+    links = [],
+    summary = "",
+    skills = [],
+    experience = [],
+    education = [],
+  } = data;
+
+  // Helpers
+  const meta = [title, location].filter(Boolean).join(" • ");
+  const contacts = [email, phone, ...links.map(l => l?.url || "").filter(Boolean)].filter(Boolean).join(" · ");
+
+  return (
+    <div className="resume">
+      <div data-paper className="paper modern">
+        {/* Header */}
+        <header className="modern-header">
+          <h1 className="modern-name">{name}</h1>
+          {meta ? <div className="modern-meta">{meta}</div> : null}
+          {contacts ? <div className="modern-contacts">{contacts}</div> : null}
+        </header>
+
+        {/* Grid layout: left meta, right body */}
+        <main className="modern-grid">
+          <aside className="modern-left">
+            {/* Profile */}
+            {summary ? (
+              <section className="modern-section">
+                <h2 className="modern-h2">Profile</h2>
+                <p className="modern-p">{summary}</p>
+              </section>
+            ) : null}
+
+            {/* Skills */}
+            {skills?.length ? (
+              <section className="modern-section">
+                <h2 className="modern-h2">Skills</h2>
+                <ul className="modern-skill-list">
+                  {skills.map((s, i) => (
+                    <li key={i} className="modern-skill">{s}</li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {/* Education */}
+            {education?.length ? (
+              <section className="modern-section">
+                <h2 className="modern-h2">Education</h2>
+                <ul className="modern-edu-list">
+                  {education.map((e, i) => (
+                    <li key={i} className="modern-edu-item avoid-break">
+                      <div className="modern-edu-line">
+                        <span className="modern-edu-school">{e.school}</span>
+                        {e.degree ? <span className="modern-edu-degree"> — {e.degree}</span> : null}
+                      </div>
+                      <div className="modern-edu-dates">
+                        {[e.start, e.end].filter(Boolean).join(" – ")}
+                      </div>
+                      {e.grade ? <div className="modern-edu-grade">{e.grade}</div> : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+          </aside>
+
+          <section className="modern-right">
+            {/* Experience */}
+            <section className="modern-section">
+              <h2 className="modern-h2">Experience</h2>
+              <ul className="modern-exp-list">
+                {(experience || []).map((x, i) => (
+                  <li key={i} className="modern-exp-item avoid-break">
+                    <div className="modern-exp-head">
+                      <div className="modern-exp-role">
+                        <span className="modern-exp-company">{x.company}</span>
+                        {x.role ? <span className="modern-exp-sep"> — </span> : null}
+                        {x.role ? <span className="modern-exp-title">{x.role}</span> : null}
+                      </div>
+                      <div className="modern-exp-dates">
+                        {[x.start, x.end || "Present"].filter(Boolean).join(" – ")}
+                      </div>
+                    </div>
+                    {x.location ? <div className="modern-exp-loc">{x.location}</div> : null}
+                    {(x.bullets || []).length ? (
+                      <ul className="modern-bullets">
+                        {x.bullets.map((b, j) => (
+                          <li key={j} className="modern-bullet">{b}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/pages/api/export-pdf.js
+++ b/pages/api/export-pdf.js
@@ -7,6 +7,7 @@ import Classic from "../../components/templates/Classic";
 import TwoCol from "../../components/templates/TwoCol";
 import Centered from "../../components/templates/Centered";
 import Sidebar from "../../components/templates/Sidebar";
+import Modern from "../../components/templates/Modern";
 
 export const config = {
   api: { bodyParser: { sizeLimit: "1mb" } },
@@ -17,6 +18,7 @@ const TEMPLATE_MAP = {
   twocol: TwoCol,
   centered: Centered,
   sidebar: Sidebar,
+  modern: Modern,
 };
 
 async function launchBrowser() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import Classic from "../components/templates/Classic";
 import TwoCol from "../components/templates/TwoCol";
 import Centered from "../components/templates/Centered";
 import Sidebar from "../components/templates/Sidebar";
+import Modern from "../components/templates/Modern";
 import { pdf } from "@react-pdf/renderer";
 import ClassicPdf from "../components/pdf/ClassicPdf";
 import CoverLetterPdf from "../components/pdf/CoverLetterPdf";
@@ -19,7 +20,8 @@ const TEMPLATE_INFO = {
   classic: "Single-column, ATS-first. Clean headings, great for online parsers and conservative employers.",
   twoCol: "Two columns with a compact sidebar. Good when you have many skills and want dense use of space.",
   centered: "Centered header with balanced sections. Reads modern while staying recruiter-friendly.",
-  sidebar: "Prominent left sidebar for skills/education; main column for experience. Great for showcasing stack breadth."
+  sidebar: "Prominent left sidebar for skills/education; main column for experience. Great for showcasing stack breadth.",
+  modern: "Two-column grid with clean hierarchy. ATS-safe by default; subtle accents only in Design mode."
 };
 
 const PdfMap = {
@@ -33,7 +35,7 @@ export default function Home() {
   const [result, setResult] = useState(null);          // { coverLetter, resumeData }
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [template, setTemplate] = useState("classic"); // classic | twoCol | centered | sidebar
+  const [template, setTemplate] = useState("classic"); // classic | twoCol | centered | sidebar | modern
 
   const [showWizard, setShowWizard] = useState(false);
   const [wizardData, setWizardData] = useState(null);
@@ -290,6 +292,7 @@ export default function Home() {
 
   const TemplateView = useMemo(() => {
     switch (template) {
+      case "modern": return Modern;
       case "twoCol": return TwoCol;
       case "centered": return Centered;
       case "sidebar": return Sidebar;
@@ -307,7 +310,7 @@ export default function Home() {
         />
         <meta
           name="keywords"
-            content="AI resume builder, cover letter generator, job description tailoring, skill cross-referencing, verified skills, willingness to learn, action verbs, quantified achievements, keyword variants, accuracy check, resume verification, cover letter tone selection, tone selector, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview, ATS PDF export, ATS optimized PDF"
+            content="AI resume builder, cover letter generator, job description tailoring, skill cross-referencing, verified skills, willingness to learn, action verbs, quantified achievements, keyword variants, accuracy check, resume verification, cover letter tone selection, tone selector, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview, ATS PDF export, ATS optimized PDF, modern resume template"
 
           />
       </Head>
@@ -402,7 +405,9 @@ export default function Home() {
                 <button className="tc-btn-quiet" onClick={startOver}>Upload New CV</button>
               </div>
               <div className="flex gap-2">
-                <button className="tc-btn-quiet" onClick={downloadCvPdf}>Download CV PDF</button>
+                {template !== "modern" && (
+                  <button className="tc-btn-quiet" onClick={downloadCvPdf}>Download CV PDF</button>
+                )}
                 <button className="tc-btn-quiet" onClick={downloadCvDocx}>Download CV DOCX</button>
                 <button className="tc-btn-quiet" onClick={downloadClPdf}>Download Cover Letter PDF</button>
                 <button className="tc-btn-quiet" onClick={downloadClDocx}>Download Cover Letter DOCX</button>

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -236,3 +236,58 @@
   .resume section { page-break-inside: avoid; }
   .resume h1, .resume h2, .resume h3 { page-break-after: avoid; }
 }
+/* ==== Modern Template (two-column) ==== */
+.paper.modern {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  line-height: 1.35;
+  padding: 24px 28px;
+}
+
+.modern-header { margin-bottom: 14px; }
+.modern-name { font-size: 28px; font-weight: 700; margin: 0; }
+.modern-meta, .modern-contacts { color: #4b5563; font-size: 13px; margin-top: 2px; }
+
+.modern-grid {
+  display: grid;
+  grid-template-columns: 1fr 2.2fr;
+  gap: 18px;
+}
+
+.modern-left, .modern-right { display: flex; flex-direction: column; gap: 14px; }
+
+.modern-section { break-inside: avoid; }
+.modern-h2 { font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; color: #374151; margin: 0 0 6px; }
+.modern-p { margin: 0; font-size: 13px; color: #111827; }
+
+.modern-skill-list { display: flex; flex-wrap: wrap; gap: 6px; margin: 0; padding: 0; list-style: none; }
+.modern-skill {
+  font-size: 12px; padding: 4px 8px; border-radius: 999px; border: 1px solid #d1d5db; background: #f9fafb;
+}
+.ats-mode .modern-skill { background: none !important; border-color: #000 !important; }
+
+.modern-edu-list, .modern-exp-list { margin: 0; padding: 0; list-style: none; }
+.modern-edu-item { display: grid; grid-template-columns: 1fr auto; gap: 2px 8px; }
+.modern-edu-line { grid-column: 1 / -1; font-weight: 600; }
+.modern-edu-dates { color: #6b7280; font-size: 12px; }
+.modern-edu-grade { font-size: 12px; color: #111827; }
+
+.modern-exp-item { margin-bottom: 10px; }
+.modern-exp-head { display: grid; grid-template-columns: 1fr auto; align-items: baseline; gap: 6px 10px; }
+.modern-exp-role { font-weight: 600; }
+.modern-exp-company { }
+.modern-exp-title { }
+.modern-exp-sep { opacity: 0.6; }
+.modern-exp-dates { color: #6b7280; font-size: 12px; }
+.modern-exp-loc { color: #4b5563; font-size: 12px; margin-top: -2px; }
+
+.modern-bullets { margin: 6px 0 0 0; padding-left: 18px; }
+.modern-bullet { margin: 0 0 3px 0; }
+
+/* Page-break helpers */
+.avoid-break { page-break-inside: avoid; }
+.no-break-after { page-break-after: avoid; }
+.no-break-before { page-break-before: avoid; }
+
+/* Design mode (subtle accents); ATS mode strips via .ats-mode overrides */
+:not(.ats-mode) .paper.modern .modern-h2 { color: #0ea5a6; }
+/* ==== End Modern Template ==== */


### PR DESCRIPTION
## Summary
- add `Modern` grid-based resume template with ATS-safe markup
- append Modern CSS styles and subtle design-mode accents
- register Modern template across UI and HTML→PDF export while hiding legacy React-PDF export

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_68bcbe2fbdbc8329b62f3319c198afe3