### PR TITLE
Display full A4 previews side by side

### DIFF
--- a/components/ui/PageViewport.jsx
+++ b/components/ui/PageViewport.jsx
@@ -1,48 +1,31 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 
 /**
  * PageViewport
- * - Shows preview content in a scrollable viewport sized to one "page".
- * - Adds arrow navigation and page counter.
- * - Auto "fit-to-width": scales the inner .paper to fill the viewport width.
+ * - Displays preview content scaled to fit the container width.
+ * - Ensures the full A4 page height is visible without internal scrolling.
  *
  * Usage:
  *   <PageViewport ariaLabel="CV preview"><TemplateComp data={...} /></PageViewport>
  */
 export default function PageViewport({ children, ariaLabel = "Preview" }) {
-  const wrapperRef = useRef(null); // scrollable viewport
-  const [pages, setPages] = useState(1);
-  const [page, setPage] = useState(1);
-  const [scale, setScale] = useState(1);
-  const A4_HEIGHT = 1123;
+  const wrapperRef = useRef(null);
 
-  // Measure pages & scale to fit width
+  // Measure & scale to fit width
   const recompute = () => {
     const el = wrapperRef.current;
     if (!el) return;
 
-    // Fit-to-width: find first .paper (your templates wrap content in .paper)
     const paper = el.querySelector(".paper");
     if (paper) {
-      // Reset scale to measure the intrinsic width
       paper.style.setProperty("--pv-scale", "1");
       const paperW = paper.scrollWidth || paper.getBoundingClientRect().width;
-      const pad = 16; // small safety padding
+      const pad = 16; // safety padding
       const targetW = el.clientWidth - pad;
-      const s = paperW ? Math.min(1.1, Math.max(0.6, targetW / paperW)) : 1; // cap to avoid over/under scaling
-      setScale(s);
+      const s = paperW ? Math.min(1, targetW / paperW) : 1;
       paper.style.setProperty("--pv-scale", String(s));
-
-      // Force viewport to match A4 aspect height after scaling
-      el.style.height = `${A4_HEIGHT * s}px`;
-
-      // Total pages based on A4 height
-      const total = Math.max(1, Math.ceil(paper.scrollHeight / A4_HEIGHT));
-      setPages(total);
-
-      // Sync current page to scrollTop
-      const current = Math.min(total, Math.max(1, Math.round(el.scrollTop / el.clientHeight) + 1));
-      setPage(current);
+      // Adjust wrapper height to scaled paper height
+      el.style.height = `${paper.scrollHeight * s}px`;
     }
   };
 
@@ -52,60 +35,21 @@ export default function PageViewport({ children, ariaLabel = "Preview" }) {
     if (!el) return;
     const ro = new ResizeObserver(recompute);
     ro.observe(el);
-    // Also watch children size
     const paper = el.querySelector(".paper");
     if (paper) ro.observe(paper);
     return () => ro.disconnect();
   }, []);
 
-  // Update page indicator on manual scroll
-  useEffect(() => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      const current = Math.min(pages, Math.max(1, Math.round(el.scrollTop / el.clientHeight) + 1));
-      setPage(current);
-    };
-    el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [pages]);
-
-  const scrollToPage = (p) => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    const clamped = Math.min(pages, Math.max(1, p));
-    el.scrollTo({ top: (clamped - 1) * el.clientHeight, behavior: "smooth" });
-  };
-  const next = () => scrollToPage(page + 1);
-  const prev = () => scrollToPage(page - 1);
-
-  const onKeyDown = (e) => {
-    if (e.key === "ArrowRight" || e.key === "PageDown") { e.preventDefault(); next(); }
-    if (e.key === "ArrowLeft" || e.key === "PageUp") { e.preventDefault(); prev(); }
-  };
-
   return (
-    <div className="page-viewport">
-      <div
-        ref={wrapperRef}
-        className="preview paged fit"
-        tabIndex={0}
-        onKeyDown={onKeyDown}
-        aria-label={ariaLabel}
-      >
-        {/* scale is applied via CSS var; inner .paper is scaled to fill width */}
-        <div className="pv-scale">
-          {children}
-        </div>
+    <div
+      ref={wrapperRef}
+      className="preview"
+      aria-label={ariaLabel}
+    >
+      {/* scale is applied via CSS var; inner .paper is scaled to fill width */}
+      <div className="pv-scale">
+        {children}
       </div>
-
-      {pages > 1 && (
-        <>
-          <button type="button" className="pager-arrow left" onClick={prev} aria-label="Previous page" disabled={page <= 1}>◀</button>
-          <div className="pager-indicator" aria-live="polite">{page} / {pages}</div>
-          <button type="button" className="pager-arrow right" onClick={next} aria-label="Next page" disabled={page >= pages}>▶</button>
-        </>
-      )}
     </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -268,22 +268,22 @@ export default function Home() {
 
   return (
     <>
-      <Head>
-        <title>TailorCV - Build or Upload a Résumé</title>
-        <meta
-          name="description"
-          content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters. Bullets are rewritten with strong action verbs, quantified achievements, and keyword variants while cross-checking against your resume to avoid fabricated experience, with selectable tone, quick ATS-optimized PDF and DOCX downloads, and page-by-page A4 previews with left/right navigation. Reuse your CV for multiple job descriptions or upload a new one anytime."
-        />
-        <meta
-          name="keywords"
-            content="AI resume builder, cover letter generator, job description tailoring, skill cross-referencing, verified skills, willingness to learn, action verbs, quantified achievements, keyword variants, accuracy check, resume verification, cover letter tone selection, tone selector, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview, page navigation, multi-page preview, ATS PDF export, ATS optimized PDF, modern resume template"
-
+        <Head>
+          <title>TailorCV - Build or Upload a Résumé</title>
+          <meta
+            name="description"
+            content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters. Bullets are rewritten with strong action verbs, quantified achievements, and keyword variants while cross-checking against your resume to avoid fabricated experience, with selectable tone, quick ATS-optimized PDF and DOCX downloads, and side-by-side A4 previews. Reuse your CV for multiple job descriptions or upload a new one anytime."
           />
-      </Head>
+          <meta
+            name="keywords"
+              content="AI resume builder, cover letter generator, job description tailoring, skill cross-referencing, verified skills, willingness to learn, action verbs, quantified achievements, keyword variants, accuracy check, resume verification, cover letter tone selection, tone selector, reuse CV, multiple job descriptions, upload new resume, ATS, resume wizard, PDF download, DOCX download, CV PDF, cover letter PDF, templates, template preview, side-by-side preview, fullscreen preview, A4 resume preview, A4 cover letter preview, ATS PDF export, ATS optimized PDF, modern resume template"
+
+            />
+        </Head>
       {phase === 'results' && result ? (
         <div className="shell">
           <main className="workspace">
-            {/* LEFT: CV preview with paging & fit */}
+            {/* LEFT: CV A4 preview */}
             <section className="pane">
               <PageViewport ariaLabel="CV preview">
                 <div className="paper">
@@ -292,7 +292,7 @@ export default function Home() {
               </PageViewport>
             </section>
 
-            {/* RIGHT: Cover letter preview with paging & fit */}
+            {/* RIGHT: Cover letter A4 preview */}
             <section className="pane">
               <PageViewport ariaLabel="Cover letter preview">
                 <div className="paper">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -133,27 +133,12 @@ pre { max-height: 70vh; overflow: auto; padding: 1rem; background: #f9f9f9; font
 html, body { font-family: "InterLocal", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
 * { font-synthesis: none; }
 
-/* ==== Layout polish, toolbar, menu, splitter ==== */
+/* ==== Layout polish, toolbar, menu ==== */
 :root{
   --ink:#111827; --muted:#6b7280; --border:#e5e7eb; --bg:#f7f7f9; --accent:#0ea5a6;
   --radius:14px; --space:16px; --space-sm:10px;
 }
 html,body{ background: var(--bg); color: var(--ink); }
-
-.shell{ max-width:1280px; margin:24px auto 120px; padding:0 20px; }
-
-/* 3 tracks: left | splitter | right; the widths are set inline via CSS vars */
-.workspace{
-  display:grid; align-items:start; gap:24px;
-  grid-template-columns: var(--left, 1fr) 8px var(--right, 1fr);
-}
-
-.pane{
-  background:#fff; border:1px solid var(--border);
-  border-radius:var(--radius); box-shadow:0 2px 12px rgba(0,0,0,.06);
-  padding:18px; min-width:0;
-}
-.preview{ height: calc(100vh - 220px); overflow:auto; border-radius:12px; }
 
 /* Sticky actions bar */
 .toolbar{
@@ -161,7 +146,7 @@ html,body{ background: var(--bg); color: var(--ink); }
   display:flex; justify-content:space-between; gap:16px;
   background:rgba(255,255,255,.8); backdrop-filter:blur(8px);
   border:1px solid var(--border); border-radius:var(--radius);
-  padding:12px; margin:18px auto 0; max-width:1280px;
+  padding:12px; margin:18px auto 0; max-width:1360px;
 }
 .group{ display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
 
@@ -194,21 +179,8 @@ html,body{ background: var(--bg); color: var(--ink); }
 }
 .menu-item:hover{ background:#f3f4f6; }
 
-/* Splitter between panes */
-.splitter{
-  width:8px; align-self:stretch; cursor:col-resize; position:relative; user-select:none; background:transparent;
-}
-.splitter::after{ content:""; position:absolute; left:3px; top:0; bottom:0; width:2px; background:var(--border); }
-.splitter.active::after{ background:var(--accent); }
-
-/* Mobile: single column, no splitter */
-@media (max-width:1024px){
-  .workspace{ grid-template-columns:1fr; }
-  .splitter{ display:none; }
-  .preview{ height: calc(100vh - 260px); }
-}
 /* ==== /Layout ==== */
-/* ==== Side-by-side paged previews with fit-to-width ==== */
+/* ==== Side-by-side fit-to-width A4 previews ==== */
 .shell{ max-width: 1360px; margin:24px auto 120px; padding:0 20px; } /* widen to reduce outer deadspace */
 .workspace{
   display:grid; align-items:start; gap:24px;
@@ -220,12 +192,10 @@ html,body{ background: var(--bg); color: var(--ink); }
   padding:14px; min-width:0;
 }
 
-/* One "page" viewport; content inside scrolls page-by-page */
-.preview.paged{
-  height: calc(100vh - 240px);
-  overflow:auto;
+/* Simple viewport showing scaled A4 paper */
+.preview{
   border-radius:12px;
-  scroll-snap-type:y mandatory;
+  overflow:visible;
 }
 /* Base A4 paper dimensions */
 .paper{
@@ -238,29 +208,10 @@ html,body{ background: var(--bg); color: var(--ink); }
   transform-origin: top center;
   margin: 0 auto; /* center the scaled page */
 }
-.preview.paged .paper{ scroll-snap-align:start; }
-
-/* Pager overlay */
-.page-viewport{ position:relative; }
-.pager-arrow{
-  position:absolute; top:50%; transform:translateY(-50%);
-  background:#fff; border:1px solid var(--border); border-radius:999px;
-  width:36px; height:36px; display:flex; align-items:center; justify-content:center;
-  cursor:pointer; box-shadow:0 4px 16px rgba(0,0,0,.08);
-}
-.pager-arrow:disabled{ opacity:.4; cursor:default; }
-.pager-arrow.left{ left:6px; }
-.pager-arrow.right{ right:6px; }
-
-.pager-indicator{
-  position:absolute; right:10px; bottom:10px;
-  background:rgba(0,0,0,.75); color:#fff; font-size:12px; padding:6px 8px; border-radius:8px;
-}
 
 /* Slightly shorter viewport on small screens */
 @media (max-width: 1200px){ .shell{ max-width: 1100px; } }
 @media (max-width: 1024px){
   .workspace{ grid-template-columns: 1fr; } /* still stacks on small screens only */
-  .preview.paged{ height: calc(100vh - 280px); }
 }
-/* ==== /Side-by-side paged previews ==== */
+/* ==== /Side-by-side fit-to-width A4 previews ==== */


### PR DESCRIPTION
## Summary
- replace paged PageViewport with simple width-fit component
- remove scrollable preview styles for clean A4 panes
- update meta description and keywords for side-by-side previews

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bccb34f25c83298fb79973309c9e8a