### PR TITLE
Add clickable fullscreen A4 preview

### DIFF
--- a/components/ui/PageViewport.jsx
+++ b/components/ui/PageViewport.jsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useLayoutEffect, useRef } from "react";
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  cloneElement,
+  isValidElement,
+} from "react";
 
 /**
  * PageViewport
@@ -10,8 +17,12 @@ import React, { useEffect, useLayoutEffect, useRef } from "react";
  */
 export default function PageViewport({ children, ariaLabel = "Preview" }) {
   const wrapperRef = useRef(null);
+  const [fullscreen, setFullscreen] = useState(false);
 
-  // Measure & scale to fit width
+  const renderContent = () =>
+    isValidElement(children) ? cloneElement(children) : children;
+
+  // Measure & scale to fit width and viewport height
   const recompute = () => {
     const el = wrapperRef.current;
     if (!el) return;
@@ -19,13 +30,18 @@ export default function PageViewport({ children, ariaLabel = "Preview" }) {
     const paper = el.querySelector(".paper");
     if (paper) {
       paper.style.setProperty("--pv-scale", "1");
-      const paperW = paper.scrollWidth || paper.getBoundingClientRect().width;
+      const rect = paper.getBoundingClientRect();
+      const paperW = paper.scrollWidth || rect.width;
+      const paperH = paper.scrollHeight || rect.height;
       const pad = 16; // safety padding
       const targetW = el.clientWidth - pad;
-      const s = paperW ? Math.min(1, targetW / paperW) : 1;
+      const sW = paperW ? Math.min(1, targetW / paperW) : 1;
+      const viewportH = window.innerHeight ? window.innerHeight - 120 : Infinity;
+      const sH = paperH ? Math.min(1, viewportH / paperH) : 1;
+      const s = Math.min(sW, sH);
       paper.style.setProperty("--pv-scale", String(s));
       // Adjust wrapper height to scaled paper height
-      el.style.height = `${paper.scrollHeight * s}px`;
+      el.style.height = `${paperH * s}px`;
     }
   };
 
@@ -37,20 +53,54 @@ export default function PageViewport({ children, ariaLabel = "Preview" }) {
     ro.observe(el);
     const paper = el.querySelector(".paper");
     if (paper) ro.observe(paper);
-    return () => ro.disconnect();
+    window.addEventListener("resize", recompute);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", recompute);
+    };
   }, []);
 
+  useEffect(() => {
+    if (fullscreen) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+  }, [fullscreen]);
+
   return (
-    <div
-      ref={wrapperRef}
-      className="preview"
-      aria-label={ariaLabel}
-    >
-      {/* scale is applied via CSS var; inner .paper is scaled to fill width */}
-      <div className="pv-scale">
-        {children}
+    <>
+      <div
+        ref={wrapperRef}
+        className="preview"
+        aria-label={ariaLabel}
+        role="button"
+        tabIndex={0}
+        onClick={() => setFullscreen(true)}
+      >
+        {/* scale is applied via CSS var; inner .paper is scaled to fill width */}
+        <div className="pv-scale">{renderContent()}</div>
       </div>
-    </div>
+      {fullscreen && (
+        <div
+          className="fullscreen-overlay"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setFullscreen(false)}
+        >
+          <div
+            className="fullscreen-inner"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="fullscreen-close"
+              aria-label="Close preview"
+              onClick={() => setFullscreen(false)}
+            >
+              &times;
+            </button>
+            {renderContent()}
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -272,7 +272,7 @@ export default function Home() {
           <title>TailorCV - Build or Upload a Résumé</title>
           <meta
             name="description"
-            content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters. Bullets are rewritten with strong action verbs, quantified achievements, and keyword variants while cross-checking against your resume to avoid fabricated experience, with selectable tone, quick ATS-optimized PDF and DOCX downloads, and side-by-side A4 previews. Reuse your CV for multiple job descriptions or upload a new one anytime."
+            content="Upload or craft a resume, then tailor it to any job description to generate ATS-friendly A4 resumes and matching cover letters. Bullets are rewritten with strong action verbs, quantified achievements, and keyword variants while cross-checking against your resume to avoid fabricated experience, with selectable tone, quick ATS-optimized PDF and DOCX downloads, and side-by-side A4 previews that open fullscreen on click. Reuse your CV for multiple job descriptions or upload a new one anytime."
           />
           <meta
             name="keywords"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -196,6 +196,7 @@ html,body{ background: var(--bg); color: var(--ink); }
 .preview{
   border-radius:12px;
   overflow:visible;
+  cursor: zoom-in;
 }
 /* Base A4 paper dimensions */
 .paper{

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -175,6 +175,7 @@
   justify-content: center;
   align-items: center;
   z-index: 1000;
+  cursor: zoom-out;
 }
 
 .fullscreen-inner {
@@ -198,7 +199,8 @@
   box-shadow: 0 1px 4px rgba(0,0,0,0.2);
 }
 
-.fullscreen-inner .a4 {
+.fullscreen-inner .a4,
+.fullscreen-inner .paper {
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 


### PR DESCRIPTION
## Summary
- enable height-aware PageViewport scaling and fullscreen overlay
- style preview and overlay with zoom cursors
- note fullscreen previews in metadata for SEO

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Module not found: Can't resolve 'puppeteer')

------
https://chatgpt.com/codex/tasks/task_e_68bccf019e248329ba8c8a860ce15a29