### PR TITLE
Fix template preview styling and theme settings

### DIFF
--- a/components/templates/Modern.jsx
+++ b/components/templates/Modern.jsx
@@ -24,17 +24,16 @@ export default function Modern({ data = {} }) {
   const contacts = [email, phone, ...links.map(l => l?.url || "").filter(Boolean)].filter(Boolean).join(" · ");
 
   return (
-    <div className="resume">
-      <div data-paper className="paper modern">
-        {/* Header */}
-        <header className="modern-header">
+    <div className="resume modern" data-paper>
+      {/* Header */}
+      <header className="modern-header">
           <h1 className="modern-name">{name}</h1>
           {meta ? <div className="modern-meta">{meta}</div> : null}
           {contacts ? <div className="modern-contacts">{contacts}</div> : null}
-        </header>
+      </header>
 
-        {/* Grid layout: left meta, right body */}
-        <main className="modern-grid">
+      {/* Grid layout: left meta, right body */}
+      <main className="modern-grid">
           <aside className="modern-left">
             {/* Profile */}
             {summary ? (
@@ -108,8 +107,7 @@ export default function Modern({ data = {} }) {
               </ul>
             </section>
           </section>
-        </main>
-      </div>
+      </main>
     </div>
   );
 }

--- a/pages/results.js
+++ b/pages/results.js
@@ -28,11 +28,17 @@ export default function ResultsPage(){
   if(!result) return null;
 
   const TemplateComp = TemplateMap[template] || Classic;
-  const resumePage = <div className="paper"><TemplateComp data={result.resumeData} /></div>;
-  const coverPage = <div className="paper cover-letter"><div className="whitespace-pre-wrap text-[11px] leading-[1.6]">{result.coverLetter || 'No cover letter returned.'}</div></div>;
+  const densityVars = {
+    compact: { '--font-size': '11px', '--line-height': '1.5' },
+    normal: { '--font-size': '12.5px', '--line-height': '1.75' },
+    cozy: { '--font-size': '14px', '--line-height': '1.9' }
+  };
+  const styleVars = { '--accent': accent, ...densityVars[density] };
+  const resumePage = <div className="paper" style={styleVars}><TemplateComp data={result.resumeData} /></div>;
+  const coverPage = <div className="paper cover-letter" style={styleVars}><div className="whitespace-pre-wrap text-[11px] leading-[1.6]">{result.coverLetter || 'No cover letter returned.'}</div></div>;
 
   async function downloadCvPdf(){
-    const res = await fetch('/api/export-pdf',{method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify({data: result.resumeData, template, mode: atsMode?'ats':'design', filename:'cv'})});
+    const res = await fetch('/api/export-pdf',{method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify({data: result.resumeData, template, mode: atsMode?'ats':'design', accent, density, filename:'cv'})});
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -59,7 +65,7 @@ export default function ResultsPage(){
     <>
       <Head>
         <title>Results – TailorCV</title>
-        <meta name="description" content="Preview and export your tailored CV and cover letter." />
+        <meta name="description" content="Preview and export your tailored CV and cover letter with customizable templates, themes, and density." />
       </Head>
       <MainShell
         left={<ControlsPanel template={template} setTemplate={setTemplate} accent={accent} setAccent={setAccent} density={density} setDensity={setDensity} atsMode={atsMode} setAtsMode={setAtsMode} onExportPdf={downloadCvPdf} onExportDocx={downloadCvDocx} onExportClPdf={downloadClPdf} onExportClDocx={downloadClDocx} page={page} pageCount={1} onPageChange={setPage} />}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -222,10 +222,11 @@ html,body{ background: var(--bg); color: var(--ink); }
   border-radius:8px;
   box-shadow:0 1px 3px rgba(0,0,0,0.08);
   overflow:hidden;
+  padding:16mm 14mm;
 }
 
 .cover-letter{
-  padding:48px;
+  padding:0;
 }
 /* scale wrapper – we scale the .paper via CSS var set by PageViewport */
 .pv-scale .paper{

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -26,7 +26,9 @@
 .resume {
   color: var(--ink);
   background: var(--bg);
-  font: 12.5px/1.75 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  font-size: var(--font-size, 12.5px);
+  line-height: var(--line-height, 1.75);
   max-width: 800px;
   margin: 0 auto;
   padding: 8px 6px;
@@ -56,7 +58,7 @@
 .sidebarMain::before { content:""; position:absolute; left:-9px; top:0; bottom:0; width:1px; background: var(--rule); }
 
 @media print {
-  @page { margin: 14mm; }
+  @page { margin: 0; }
   body { background: #fff; }
 }
 
@@ -239,10 +241,9 @@
   .resume h1, .resume h2, .resume h3 { page-break-after: avoid; }
 }
 /* ==== Modern Template (two-column) ==== */
-.paper.modern {
+.modern {
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
   line-height: 1.35;
-  padding: 24px 28px;
 }
 
 .modern-header { margin-bottom: 14px; }
@@ -291,26 +292,25 @@
 .no-break-before { page-break-before: avoid; }
 
 /* Design mode (subtle accents); ATS mode strips via .ats-mode overrides */
-:not(.ats-mode) .paper.modern .modern-h2 { color: #0ea5a6; }
+:not(.ats-mode) .modern .modern-h2 { color: var(--accent); }
 /* ==== End Modern Template ==== */
 
 /* ==== Modern ATS print fixes ==== */
 @media print {
   /* Stack columns in print to avoid grid pagination bugs */
-  .paper.modern .modern-grid{ display:block !important; }
-  .paper.modern .modern-left,
-  .paper.modern .modern-right{ display:block !important; break-inside:auto !important; }
+  .modern .modern-grid{ display:block !important; }
+  .modern .modern-left,
+  .modern .modern-right{ display:block !important; break-inside:auto !important; }
 
   /* Only prevent breaks on small items, not entire sections */
-  .paper.modern .modern-edu-item,
-  .paper.modern .modern-exp-item{ break-inside: avoid; }
+  .modern .modern-edu-item,
+  .modern .modern-exp-item{ break-inside: avoid; }
 
   /* Tighten spacing in ATS to reduce overflow */
-  .paper.modern{ padding:16mm 14mm; } /* aligns with exporter margins */
-  .paper.modern .modern-header{ margin-bottom:8px; }
-  .paper.modern .modern-grid{ gap:12px !important; }
-  .paper.modern .modern-left, .paper.modern .modern-right{ gap:10px !important; }
-  .paper.modern .modern-bullets{ margin-top:4px !important; }
+  .modern .modern-header{ margin-bottom:8px; }
+  .modern .modern-grid{ gap:12px !important; }
+  .modern .modern-left, .modern .modern-right{ gap:10px !important; }
+  .modern .modern-bullets{ margin-top:4px !important; }
 }
 /* ATS overrides already force monochrome; keep them. */
 /* ==== /Modern ATS print fixes ==== */


### PR DESCRIPTION
## Summary
- add padding and style variables to preview pages for accurate exports
- enable theme color and density controls across templates and PDF export
- repair Modern template layout and refine print styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6e0a474c8329920e5d10f89710dc