### PR TITLE
Sync preview ATS mode with export

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -18,7 +18,7 @@ export default function ResultsPage(){
   const [template, setTemplate] = useState('classic');
   const [accent, setAccent] = useState('#00C9A7');
   const [density, setDensity] = useState('normal');
-  const [atsMode, setAtsMode] = useState(true);
+  const [atsMode, setAtsMode] = useState(false);
   const [page, setPage] = useState(0);
 
   useEffect(()=>{
@@ -34,8 +34,18 @@ export default function ResultsPage(){
     cozy: { '--font-size': '14px', '--line-height': '1.9' }
   };
   const styleVars = { '--accent': accent, ...densityVars[density] };
-  const resumePage = <div className="paper" style={styleVars}><TemplateComp data={result.resumeData} /></div>;
-  const coverPage = <div className="paper cover-letter" style={styleVars}><div className="whitespace-pre-wrap text-[11px] leading-[1.6]">{result.coverLetter || 'No cover letter returned.'}</div></div>;
+  const resumePage = (
+    <div className={`paper ${atsMode ? 'ats-mode' : ''}`} style={styleVars}>
+      <TemplateComp data={result.resumeData} />
+    </div>
+  );
+  const coverPage = (
+    <div className={`paper cover-letter ${atsMode ? 'ats-mode' : ''}`} style={styleVars}>
+      <div className="whitespace-pre-wrap text-[11px] leading-[1.6]">
+        {result.coverLetter || 'No cover letter returned.'}
+      </div>
+    </div>
+  );
 
   async function downloadCvPdf(){
     const res = await fetch('/api/export-pdf',{method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify({data: result.resumeData, template, mode: atsMode?'ats':'design', accent, density, filename:'cv'})});
@@ -65,7 +75,7 @@ export default function ResultsPage(){
     <>
       <Head>
         <title>Results – TailorCV</title>
-        <meta name="description" content="Preview and export your tailored CV and cover letter with customizable templates, themes, and density." />
+        <meta name="description" content="Preview and export your tailored CV and cover letter with customizable templates, themes, density, and ATS-friendly mode." />
       </Head>
       <MainShell
         left={<ControlsPanel template={template} setTemplate={setTemplate} accent={accent} setAccent={setAccent} density={density} setDensity={setDensity} atsMode={atsMode} setAtsMode={setAtsMode} onExportPdf={downloadCvPdf} onExportDocx={downloadCvDocx} onExportClPdf={downloadClPdf} onExportClDocx={downloadClDocx} page={page} pageCount={1} onPageChange={setPage} />}


### PR DESCRIPTION
## Summary
- Default ATS mode off so downloaded PDF matches preview
- Apply ATS styling to preview pages for accurate comparison
- Mention ATS-friendly mode in page description for SEO

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd718ea9f48329b975b31c5f4c9d9e