### PR TITLE
Fix multi-page CV preview and PDF layout

### DIFF
--- a/components/ui/PreviewPane.jsx
+++ b/components/ui/PreviewPane.jsx
@@ -1,13 +1,12 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import PageViewport from './PageViewport';
 
-export default function PreviewPane({ content }) {
+export default function PreviewPane({ content, page = 0, onPageChange }) {
   // content: array of page elements
   const pages = useMemo(() => content || [], [content]);
-  const [page, setPage] = useState(0);
   const pageCount = pages.length || 1;
   return (
-    <PageViewport page={page} pageCount={pageCount} onPageChange={setPage} ariaLabel="Document preview">
+    <PageViewport page={page} pageCount={pageCount} onPageChange={onPageChange} ariaLabel="Document preview">
       {pages[page]}
     </PageViewport>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -216,13 +216,14 @@ html,body{ background: var(--bg); color: var(--ink); }
 /* Base A4 paper dimensions */
 .paper{
   width:794px;
-  min-height:1123px;
+  height:1123px;
   background:#fff;
   border:1px solid var(--border);
   border-radius:8px;
   box-shadow:0 1px 3px rgba(0,0,0,0.08);
   overflow:hidden;
   padding:16mm 14mm;
+  position:relative;
 }
 
 .cover-letter{

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -236,8 +236,7 @@
 }
 @media print {
   html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-  /* Prevent ugly breaks inside key blocks */
-  .resume section { page-break-inside: avoid; }
+  /* Avoid page breaks directly after headings */
   .resume h1, .resume h2, .resume h3 { page-break-after: avoid; }
 }
 /* ==== Modern Template (two-column) ==== */


### PR DESCRIPTION
## Summary
- Paginate CV preview into true A4 pages with navigation and updated SEO description
- Allow external page control by refactoring PreviewPane
- Adjust paper and print styles to keep headers with content in PDF output

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdd38b048483299e33c20392086048