### PR TITLE
Fix preview navigation placement and template switching in CV viewer

### DIFF
--- a/components/ui/PageViewport.jsx
+++ b/components/ui/PageViewport.jsx
@@ -42,6 +42,8 @@ export default function PageViewport({ children, ariaLabel = "Preview", page = 0
       const sH = paperH ? Math.min(1, viewportH / paperH) : 1;
       const s = Math.min(sW, sH);
       paper.style.setProperty("--pv-scale", String(s));
+      // expose scaled width for overlay positioning
+      el.style.setProperty("--pv-width", `${paperW * s}px`);
       // Adjust wrapper height to scaled paper height
       el.style.height = `${paperH * s}px`;
     }

--- a/components/ui/PreviewPane.jsx
+++ b/components/ui/PreviewPane.jsx
@@ -1,13 +1,16 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import PageViewport from './PageViewport';
 
 export default function PreviewPane({ content, page = 0, onPageChange }) {
   // content: array of page elements
   const pages = useMemo(() => content || [], [content]);
   const pageCount = pages.length || 1;
+  useEffect(() => {
+    if (page >= pageCount) onPageChange && onPageChange(0);
+  }, [page, pageCount, onPageChange]);
   return (
     <PageViewport page={page} pageCount={pageCount} onPageChange={onPageChange} ariaLabel="Document preview">
-      {pages[page]}
+      {pages[Math.min(page, pageCount - 1)]}
     </PageViewport>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -212,6 +212,7 @@ html,body{ background: var(--bg); color: var(--ink); }
   border-radius:12px;
   overflow:visible;
   cursor: zoom-in;
+  position: relative; /* anchor pager overlay */
 }
 /* Base A4 paper dimensions */
 .paper{

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -100,9 +100,9 @@
 .pager {
   position: absolute;
   top: 50%;
-  left: 0;
-  right: 0;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--pv-width, 100%);
   display: flex;
   justify-content: space-between;
   padding: 0 8px;


### PR DESCRIPTION
## Summary
- keep page navigation arrows centered on the A4 preview
- reset preview page when templates change to avoid blank displays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: next: not found)
- `npm install` *(fails: dependency conflicts; attempted --legacy-peer-deps but installation was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd7b4aed88329af413516cb63ac1d