### PR TITLE
Fix fullscreen preview scaling and show CV & cover letter side by side

### DIFF
--- a/components/ui/PageViewport.jsx
+++ b/components/ui/PageViewport.jsx
@@ -46,8 +46,14 @@ export default function PageViewport({ children, ariaLabel = "Preview", page = 0
       paper.style.setProperty("--pv-scale", String(s));
       // expose scaled width for overlay positioning
       el.style.setProperty("--pv-width", `${paperW * s}px`);
-      // Adjust wrapper height to scaled paper height
-      el.style.height = `${paperH * s}px`;
+      // Adjust wrapper height/width; keep 100% height in fullscreen
+      if (fullscreenMode) {
+        el.style.height = "";
+        el.style.width = `${paperW * s}px`;
+      } else {
+        el.style.width = "";
+        el.style.height = `${paperH * s}px`;
+      }
     }
   };
 

--- a/pages/results.js
+++ b/pages/results.js
@@ -107,7 +107,7 @@ export default function ResultsPage(){
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="Preview and export your tailored CV and cover letter with responsive, fullscreen A4 previews, customizable templates, themes, density, and ATS-friendly mode."
+          content="Preview and export your tailored CV and cover letter with responsive side-by-side and fullscreen A4 previews, customizable templates, themes, density, and ATS-friendly mode."
         />
       </Head>
       <MainShell
@@ -131,7 +131,7 @@ export default function ResultsPage(){
           />
         }
         right={
-          <div className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
             <div className="pane">
               <PreviewPane content={resumePages} page={page} onPageChange={setPage} />
             </div>


### PR DESCRIPTION
## Summary
- keep fullscreen overlay height fluid to center previews
- display CV and cover letter previews side by side
- update results page meta description for SEO

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68be0328e180832987058e1327d5f1eb