### PR TITLE
Fix preview rendering and fullscreen scaling

### DIFF
--- a/components/ui/PageViewport.jsx
+++ b/components/ui/PageViewport.jsx
@@ -59,10 +59,11 @@ export default function PageViewport({ children, ariaLabel = "Preview", page = 0
     }
   };
 
-  useLayoutEffect(() => recompute(wrapperRef.current), []);
+  useLayoutEffect(() => recompute(wrapperRef.current), [children]);
   useEffect(() => {
     const el = wrapperRef.current;
     if (!el) return;
+    recompute(el);
     const ro = new ResizeObserver(() => recompute(el));
     ro.observe(el);
     const parent = el.parentElement;
@@ -82,7 +83,7 @@ export default function PageViewport({ children, ariaLabel = "Preview", page = 0
       window.removeEventListener("resize", handle);
       window.removeEventListener("keydown", key);
     };
-  }, [page, pageCount, onPageChange, fullscreen]);
+  }, [children, page, pageCount, onPageChange, fullscreen]);
 
   // recompute when fullscreen is active
   useEffect(() => {
@@ -100,7 +101,7 @@ export default function PageViewport({ children, ariaLabel = "Preview", page = 0
       ro.disconnect();
       window.removeEventListener("resize", handle);
     };
-  }, [fullscreen, page, pageCount]);
+  }, [fullscreen, page, pageCount, children]);
 
   useEffect(() => {
     if (fullscreen) document.body.style.overflow = "hidden";


### PR DESCRIPTION
## Summary
- ensure PageViewport recomputes dimensions when preview content changes
- fix fullscreen preview scaling when content updates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be073151408329a77b31be9e98a660