### PR TITLE
Improve CV preview pagination and export

### DIFF
--- a/components/templates/Centered.jsx
+++ b/components/templates/Centered.jsx
@@ -31,7 +31,7 @@ export default function Centered({ data = {} }) {
 
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
-        <section key={i}>
+        <section key={i} className="avoid-break">
           {x.company && <strong>{x.company}</strong>}
           {x.role && <div>{x.role}</div>}
           {(x.start || x.end != null) && (

--- a/components/templates/Classic.jsx
+++ b/components/templates/Classic.jsx
@@ -31,7 +31,7 @@ export default function Classic({ data = {} }) {
 
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
-        <section key={i}>
+        <section key={i} className="avoid-break">
           {x.company && <strong>{x.company}</strong>}
           {x.role && <div>{x.role}</div>}
           {(x.start || x.end != null) && (

--- a/components/templates/Sidebar.jsx
+++ b/components/templates/Sidebar.jsx
@@ -52,7 +52,7 @@ export default function Sidebar({ data = {} }) {
         {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
-          <section key={i}>
+          <section key={i} className="avoid-break">
             {x.company && <strong>{x.company}</strong>}
             {x.role && <div>{x.role}</div>}
             {(x.start || x.end != null) && (

--- a/components/templates/TwoCol.jsx
+++ b/components/templates/TwoCol.jsx
@@ -52,7 +52,7 @@ export default function TwoCol({ data = {} }) {
         {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
-          <section key={i}>
+          <section key={i} className="avoid-break">
             {x.company && <strong>{x.company}</strong>}
             {x.role && <div>{x.role}</div>}
             {(x.start || x.end != null) && (

--- a/components/ui/Preview.jsx
+++ b/components/ui/Preview.jsx
@@ -11,7 +11,7 @@ export default function Preview({ pages = [], page = 0, onPageChange }) {
     if (!el) return;
     const paper = el.querySelector('.paper');
     if (!paper) return;
-    const scale = el.clientWidth / paper.scrollWidth;
+    const scale = Math.min(el.clientWidth / paper.scrollWidth, 1);
     paper.style.transform = `scale(${scale})`;
     paper.style.transformOrigin = 'top left';
     el.style.height = `${paper.scrollHeight * scale}px`;
@@ -21,9 +21,9 @@ export default function Preview({ pages = [], page = 0, onPageChange }) {
     <div className="preview" ref={containerRef} aria-label="Document preview">
       {content}
       {pageCount > 1 && (
-        <div className="pager">
+        <>
           <button
-            className="pager-btn"
+            className="pager-btn pager-left"
             onClick={() => onPageChange && onPageChange(Math.max(page - 1, 0))}
             disabled={page === 0}
             aria-label="Previous page"
@@ -34,14 +34,14 @@ export default function Preview({ pages = [], page = 0, onPageChange }) {
             {page + 1} / {pageCount}
           </span>
           <button
-            className="pager-btn"
+            className="pager-btn pager-right"
             onClick={() => onPageChange && onPageChange(Math.min(page + 1, pageCount - 1))}
             disabled={page === pageCount - 1}
             aria-label="Next page"
           >
             <Icon name="right" />
           </button>
-        </div>
+        </>
       )}
     </div>
   );

--- a/pages/api/export-pdf.js
+++ b/pages/api/export-pdf.js
@@ -78,7 +78,7 @@ html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<style>${INLINED_CSS}\n/* --- ATS overrides --- */\n${atsCss}</style>
+<style>${INLINED_CSS}\n.paper{height:auto !important;overflow:visible !important;}\n/* --- ATS overrides --- */\n${atsCss}</style>
 </head>
 <body class="${mode === "ats" ? "ats-mode" : ""}">
   <div class="paper" style="${styleVars}">${body}</div>

--- a/pages/results.js
+++ b/pages/results.js
@@ -50,17 +50,25 @@ export default function ResultsPage(){
     root.render(<TemplateComp data={result.resumeData} />);
     requestAnimationFrame(() => {
       const total = off.scrollHeight;
-      const count = Math.max(1, Math.ceil(total / pageHeight));
-      const arr = [];
-      for (let i = 0; i < count; i++) {
-        arr.push(
-          <div className={`paper ${atsMode ? 'ats-mode' : ''}`} style={styleVars} key={i}>
-            <div style={{ position: 'relative', top: -i * pageHeight }}>
-              <TemplateComp data={result.resumeData} />
-            </div>
-          </div>
-        );
+      const items = Array.from(off.querySelectorAll('.avoid-break'));
+      const positions = [];
+      let start = 0;
+      while (start < total) {
+        let end = start + pageHeight;
+        const crossing = items.find(el => el.offsetTop < end && (el.offsetTop + el.offsetHeight) > end);
+        if (crossing && crossing.offsetTop > start) {
+          end = crossing.offsetTop;
+        }
+        positions.push(start);
+        start = end;
       }
+      const arr = positions.map((pos, i) => (
+        <div className={`paper ${atsMode ? 'ats-mode' : ''}`} style={styleVars} key={i}>
+          <div style={{ position: 'relative', top: -pos }}>
+            <TemplateComp data={result.resumeData} />
+          </div>
+        </div>
+      ));
       setResumePages(arr);
       root.unmount();
       document.body.removeChild(off);
@@ -107,7 +115,7 @@ export default function ResultsPage(){
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="View and export your tailored CV and cover letter with responsive A4 display, customizable templates, themes, density, and ATS-friendly mode."
+          content="View and export your tailored CV and cover letter with responsive A4 display, side navigation controls, seamless multi-page downloads, customizable templates, themes, density, and ATS-friendly mode."
         />
       </Head>
       <MainShell

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -212,6 +212,8 @@ html,body{ background: var(--bg); color: var(--ink); }
   border-radius:12px;
   overflow:hidden;
   position: relative; /* anchor pager overlay */
+  max-width:794px;
+  margin:0 auto;
 }
 /* Base A4 paper dimensions */
 .paper{
@@ -231,14 +233,6 @@ html,body{ background: var(--bg); color: var(--ink); }
 }
 
 /* Pager controls */
-.pager{
-  position:absolute;
-  bottom:8px;
-  right:8px;
-  display:flex;
-  gap:4px;
-}
-
 .pager-btn{
   width:32px;
   height:32px;
@@ -250,7 +244,13 @@ html,body{ background: var(--bg); color: var(--ink); }
   font-size:20px;
   line-height:1;
   cursor:pointer;
+  position:absolute;
+  top:50%;
+  transform:translateY(-50%);
 }
+
+.pager-left{ left:8px; }
+.pager-right{ right:8px; }
 
 .pager-btn:disabled{
   opacity:0.5;


### PR DESCRIPTION
## Summary
- Position page navigation arrows on the sides of the A4 preview and prevent upscaling beyond A4 dimensions.
- Preserve entire experience blocks when splitting CVs across pages and enable full multi-page PDF export.
- Refresh results page meta description for improved SEO.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be0ee503b88329a611fc9c30a8fb42