### PR TITLE
fix: multi-page cv formatting parity

### DIFF
--- a/pages/api/export-pdf.js
+++ b/pages/api/export-pdf.js
@@ -78,10 +78,10 @@ html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<style>${INLINED_CSS}\n.paper{height:auto !important;overflow:visible !important;}\n/* --- ATS overrides --- */\n${atsCss}</style>
+<style>${INLINED_CSS}\n@page{margin:16mm 14mm;}\n.paper{width:auto !important;height:auto !important;overflow:visible !important;padding:0 !important;margin:0 !important;border:none !important;box-shadow:none !important;}\n/* --- ATS overrides --- */\n${atsCss}</style>
 </head>
-<body class="${mode === "ats" ? "ats-mode" : ""}">
-  <div class="paper" style="${styleVars}">${body}</div>
+<body class="${mode === "ats" ? "ats-mode" : ""}" style="${styleVars}">
+  <div class="paper">${body}</div>
 </body>
 </html>`;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -196,7 +196,7 @@ html,body{ background: var(--bg); color: var(--ink); }
 
 /* ==== /Layout ==== */
 /* ==== Side-by-side fit-to-width A4 previews ==== */
-.shell{ max-width: 1360px; margin:24px auto 120px; padding:0 20px; } /* widen to reduce outer deadspace */
+.shell{ max-width: 1360px; margin:24px auto 48px; padding:0 20px; } /* widen to reduce outer deadspace */
 .workspace{
   display:grid; align-items:start; gap:24px;
   grid-template-columns: 1fr 1fr; /* keep two panes */


### PR DESCRIPTION
## Summary
- ensure exported PDFs keep consistent margins on every page
- tighten results layout spacing under CV and cover letter previews

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be124ee8688329a017ae6b4826607e