### PR TITLE
feat: add side-by-side A4 previews with lightbox

### DIFF
--- a/components/ui/A4Preview.jsx
+++ b/components/ui/A4Preview.jsx
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+export default function A4Preview({ children, scale = 0.72, className = "" }) {
+  const style = useMemo(() => ({
+    width: 794,
+    height: 1123,
+    transform: `scale(${scale})`,
+  }), [scale]);
+  return (
+    <div className={`relative overflow-hidden ${className}`}>
+      <div
+        className="origin-top-left bg-white shadow-[0_0_0_1px_rgba(0,0,0,0.08),0_10px_25px_rgba(0,0,0,0.08)]"
+        style={style}
+      >
+        <style>{`
+          .a4-scope * { box-sizing: border-box; }
+          .a4-scope img, .a4-scope canvas, .a4-scope svg, .a4-scope iframe, .a4-scope video {
+            max-width: none !important;
+            width: auto;
+            height: auto;
+          }
+        `}</style>
+        <div className="a4-scope w-full h-full">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/LightboxModal.jsx
+++ b/components/ui/LightboxModal.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+export default function LightboxModal({ open, onClose, children, onPrev, onNext, canPrev, canNext, pageLabel }) {
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e) {
+      if (e.key === "Escape") onClose?.();
+      if (e.key === "ArrowLeft" && canPrev) onPrev?.();
+      if (e.key === "ArrowRight" && canNext) onNext?.();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, canPrev, canNext, onClose, onPrev, onNext]);
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/80 flex items-center justify-center">
+      <button onClick={onClose} className="absolute top-4 right-4 text-white/90 text-xl px-3 py-1 rounded hover:bg-white/10" aria-label="Close">✕</button>
+      {canPrev && <button onClick={onPrev} className="absolute left-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10" aria-label="Previous">←</button>}
+      {canNext && <button onClick={onNext} className="absolute right-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10" aria-label="Next">→</button>}
+      <div className="relative bg-white shadow-2xl">{children}</div>
+      {pageLabel && <div className="absolute bottom-4 inset-x-0 text-center text-white/80 text-sm">{pageLabel}</div>}
+    </div>
+  );
+}

--- a/components/ui/PageCarousel.jsx
+++ b/components/ui/PageCarousel.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import A4Preview from "./A4Preview";
+export default function PageCarousel({ title, pages, scale = 0.72, index, setIndex, onOpenLightbox }) {
+  const count = Array.isArray(pages) ? pages.length : 0;
+  const canPrev = index > 0;
+  const canNext = index < count - 1;
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === "ArrowLeft" && canPrev) setIndex(i => Math.max(0, i - 1));
+      if (e.key === "ArrowRight" && canNext) setIndex(i => Math.min(count - 1, i + 1));
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [canPrev, canNext, count, setIndex]);
+  if (!count) return <div className="border rounded-lg p-6 text-sm text-zinc-500">No pages</div>;
+  return (
+    <div className="relative">
+      {title && <div className="text-sm font-medium mb-3">{title}</div>}
+      {canPrev && <button onClick={() => setIndex(i => Math.max(0, i - 1))} className="absolute left-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded">←</button>}
+      {canNext && <button onClick={() => setIndex(i => Math.min(count - 1, i + 1))} className="absolute right-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded">→</button>}
+      <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 text-xs text-zinc-600">{index + 1} / {count}</div>
+      <div className="cursor-zoom-in" onClick={onOpenLightbox}>
+        <A4Preview scale={scale}>{pages[index]}</A4Preview>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add A4Preview, PageCarousel, and LightboxModal components for accurate A4 page rendering
- show resume and cover letter previews side-by-side with keyboard and arrow navigation
- enable fullscreen lightbox with ESC to close

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be1fe3bb88832982afe135803bd237