### PR TITLE
fix: resolve PageCarousel and LightboxModal import paths

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -11,8 +11,8 @@ import Sidebar from '../components/templates/Sidebar';
 import Modern from '../components/templates/Modern';
 import { pdf } from '@react-pdf/renderer';
 import CoverLetterPdf from '../components/pdf/CoverLetterPdf';
-import PageCarousel from '@/components/ui/PageCarousel';
-import LightboxModal from '@/components/ui/LightboxModal';
+import PageCarousel from '../components/ui/PageCarousel';
+import LightboxModal from '../components/ui/LightboxModal';
 
 const TemplateMap = { classic: Classic, twoCol: TwoCol, centered: Centered, sidebar: Sidebar, modern: Modern };
 


### PR DESCRIPTION
## Summary
- fix results page imports for PageCarousel and LightboxModal to use relative paths

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68be2326dc6883299d9a14fe1140ae4b