### PR TITLE
feat: responsive A4 preview scaling

### DIFF
--- a/components/ui/PageCarousel.jsx
+++ b/components/ui/PageCarousel.jsx
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
-import A4Preview from "./A4Preview";
-export default function PageCarousel({ title, pages, scale = 0.72, index, setIndex, onOpenLightbox }) {
+import { useEffect, Fragment } from "react";
+
+export default function PageCarousel({ title, pages, index, setIndex, onOpenLightbox, Wrapper = Fragment }) {
   const count = Array.isArray(pages) ? pages.length : 0;
   const canPrev = index > 0;
   const canNext = index < count - 1;
@@ -13,14 +13,29 @@ export default function PageCarousel({ title, pages, scale = 0.72, index, setInd
     return () => window.removeEventListener("keydown", onKey);
   }, [canPrev, canNext, count, setIndex]);
   if (!count) return <div className="border rounded-lg p-6 text-sm text-zinc-500">No pages</div>;
+  const Wrap = Wrapper || Fragment;
   return (
     <div className="relative">
       {title && <div className="text-sm font-medium mb-3">{title}</div>}
-      {canPrev && <button onClick={() => setIndex(i => Math.max(0, i - 1))} className="absolute left-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded">←</button>}
-      {canNext && <button onClick={() => setIndex(i => Math.min(count - 1, i + 1))} className="absolute right-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded">→</button>}
+      {canPrev && (
+        <button
+          onClick={() => setIndex(i => Math.max(0, i - 1))}
+          className="absolute left-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded"
+        >
+          ←
+        </button>
+      )}
+      {canNext && (
+        <button
+          onClick={() => setIndex(i => Math.min(count - 1, i + 1))}
+          className="absolute right-0 top-1/2 -translate-y-1/2 z-10 px-2 py-1 bg-white/80 border rounded"
+        >
+          →
+        </button>
+      )}
       <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 text-xs text-zinc-600">{index + 1} / {count}</div>
       <div className="cursor-zoom-in" onClick={onOpenLightbox}>
-        <A4Preview scale={scale}>{pages[index]}</A4Preview>
+        <Wrap>{pages[index]}</Wrap>
       </div>
     </div>
   );

--- a/components/ui/ResponsiveA4Preview.jsx
+++ b/components/ui/ResponsiveA4Preview.jsx
@@ -1,0 +1,31 @@
+import { useMemo, useRef } from "react";
+import useContainerWidthFactory from "./useContainerWidth";
+import A4Preview from "./A4Preview";
+
+const TARGET_RENDERED_WIDTH = 740; // what we want visually on desktop
+const INNER_WIDTH = 794; // A4 inner width in px
+
+export default function ResponsiveA4Preview({ children, className = "" }) {
+  const containerRef = useRef(null);
+  const useWidth = useContainerWidthFactory(containerRef);
+  const containerWidth = useWidth();
+
+  // base scale for target size
+  const targetScale = TARGET_RENDERED_WIDTH / INNER_WIDTH;
+  // if container is tighter, shrink to fit; leave a small gutter
+  const maxUsable = Math.max(0, containerWidth - 24); // 24px padding/gutter
+  const fitScale = maxUsable > 0 ? Math.min(targetScale, maxUsable / INNER_WIDTH) : targetScale;
+
+  const scale = useMemo(() => {
+    // clamp between 0.5 and 1.0 for sanity
+    return Math.max(0.5, Math.min(1.0, fitScale || targetScale));
+  }, [fitScale]);
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <A4Preview scale={scale}>
+        {children}
+      </A4Preview>
+    </div>
+  );
+}

--- a/components/ui/useContainerWidth.js
+++ b/components/ui/useContainerWidth.js
@@ -1,0 +1,24 @@
+export default function useContainerWidth(ref, deps = []) {
+  return (() => {
+    // minimal inline hook to avoid external deps
+    let width = 0;
+    return function useMeasuredWidth() {
+      const React = require("react");
+      const { useEffect, useState } = React;
+      const [w, setW] = useState(width);
+      useEffect(() => {
+        if (!ref.current) return;
+        const ro = new ResizeObserver(entries => {
+          for (const e of entries) {
+            const cw = e.contentRect?.width || ref.current.offsetWidth || 0;
+            width = cw;
+            setW(cw);
+          }
+        });
+        ro.observe(ref.current);
+        return () => ro.disconnect();
+      }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+      return w;
+    };
+  })();
+}

--- a/pages/results.js
+++ b/pages/results.js
@@ -13,6 +13,7 @@ import { pdf } from '@react-pdf/renderer';
 import CoverLetterPdf from '../components/pdf/CoverLetterPdf';
 import PageCarousel from '../components/ui/PageCarousel';
 import LightboxModal from '../components/ui/LightboxModal';
+import ResponsiveA4Preview from '../components/ui/ResponsiveA4Preview';
 
 const TemplateMap = { classic: Classic, twoCol: TwoCol, centered: Centered, sidebar: Sidebar, modern: Modern };
 
@@ -152,6 +153,7 @@ export default function ResultsPage(){
               index={rIndex}
               setIndex={(i)=>{setRIndex(i); setPage(i);}}
               onOpenLightbox={()=>setLightbox({ type: 'resume' })}
+              Wrapper={ResponsiveA4Preview}
             />
             <PageCarousel
               title="Cover Letter"
@@ -159,6 +161,7 @@ export default function ResultsPage(){
               index={cIndex}
               setIndex={setCIndex}
               onOpenLightbox={()=>setLightbox({ type: 'cover' })}
+              Wrapper={ResponsiveA4Preview}
             />
           </div>
         }


### PR DESCRIPTION
## Summary
- add hook to track container width
- introduce ResponsiveA4Preview to scale A4 pages to ~740px while respecting aspect ratio
- wrap resume and cover letter carousels with responsive preview wrapper

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68be251e40008329afbc923e4cea1c72