### PR TITLE
Limit fullscreen preview size

### DIFF
--- a/components/ui/LightboxModal.jsx
+++ b/components/ui/LightboxModal.jsx
@@ -1,5 +1,22 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+
 export default function LightboxModal({ open, onClose, children, onPrev, onNext, canPrev, canNext, pageLabel }) {
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function updateScale() {
+      const vw = window.innerWidth - 32;
+      const vh = window.innerHeight - 32;
+      setScale(Math.min(vw / 794, vh / 1123, 1));
+    }
+
+    updateScale();
+    window.addEventListener("resize", updateScale);
+    return () => window.removeEventListener("resize", updateScale);
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     function onKey(e) {
@@ -10,14 +27,45 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open, canPrev, canNext, onClose, onPrev, onNext]);
+
   if (!open) return null;
+
   return (
     <div className="fixed inset-0 z-[100] bg-black/80 flex items-center justify-center">
-      <button onClick={onClose} className="absolute top-4 right-4 text-white/90 text-xl px-3 py-1 rounded hover:bg-white/10" aria-label="Close">✕</button>
-      {canPrev && <button onClick={onPrev} className="absolute left-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10" aria-label="Previous">←</button>}
-      {canNext && <button onClick={onNext} className="absolute right-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10" aria-label="Next">→</button>}
-      <div className="relative bg-white shadow-2xl">{children}</div>
-      {pageLabel && <div className="absolute bottom-4 inset-x-0 text-center text-white/80 text-sm">{pageLabel}</div>}
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 text-white/90 text-xl px-3 py-1 rounded hover:bg-white/10"
+        aria-label="Close"
+      >
+        ✕
+      </button>
+      {canPrev && (
+        <button
+          onClick={onPrev}
+          className="absolute left-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10"
+          aria-label="Previous"
+        >
+          ←
+        </button>
+      )}
+      {canNext && (
+        <button
+          onClick={onNext}
+          className="absolute right-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10"
+          aria-label="Next"
+        >
+          →
+        </button>
+      )}
+      <div
+        className="relative bg-white shadow-2xl"
+        style={{ width: 794 * scale, height: 1123 * scale }}
+      >
+        <div style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}>{children}</div>
+      </div>
+      {pageLabel && (
+        <div className="absolute bottom-4 inset-x-0 text-center text-white/80 text-sm">{pageLabel}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Scale LightboxModal content to fit within the viewport
- Keep resume navigation controls and lightbox interactions intact

## Testing
- `npm test` *(fails: Missing script: "test"`*)

------
https://chatgpt.com/codex/tasks/task_e_68be26c4e7b88329bf6e35d8476d784e