### PR TITLE
Align preview container size and cover letter padding

### DIFF
--- a/components/ui/A4Preview.jsx
+++ b/components/ui/A4Preview.jsx
@@ -1,15 +1,25 @@
 import { useMemo } from "react";
 export default function A4Preview({ children, scale = 0.72, className = "" }) {
-  const style = useMemo(() => ({
-    width: 794,
-    height: 1123,
-    transform: `scale(${scale})`,
-  }), [scale]);
+  const innerStyle = useMemo(
+    () => ({
+      width: 794,
+      height: 1123,
+      transform: `scale(${scale})`,
+    }),
+    [scale]
+  );
+  const outerStyle = useMemo(
+    () => ({
+      width: 794 * scale,
+      height: 1123 * scale,
+    }),
+    [scale]
+  );
   return (
-    <div className={`relative overflow-hidden ${className}`}>
+    <div className={`relative overflow-hidden ${className}`} style={outerStyle}>
       <div
         className="origin-top-left bg-white shadow-[0_0_0_1px_rgba(0,0,0,0.08),0_10px_25px_rgba(0,0,0,0.08)]"
-        style={style}
+        style={innerStyle}
       >
         <style>{`
           .a4-scope * { box-sizing: border-box; }

--- a/pages/results.js
+++ b/pages/results.js
@@ -85,8 +85,10 @@ export default function ResultsPage(){
 
   const coverPage = (
     <div className={`paper cover-letter ${atsMode ? 'ats-mode' : ''}`} style={styleVars}>
-      <div className="whitespace-pre-wrap text-[11px] leading-[1.6]">
-        {result.coverLetter || 'No cover letter returned.'}
+      <div className="text-[11px] leading-[1.6] space-y-[10px]">
+        {(result.coverLetter || 'No cover letter returned.').split(/\n+/).map((line, i) => (
+          <p key={i}>{line}</p>
+        ))}
       </div>
     </div>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -229,7 +229,7 @@ html,body{ background: var(--bg); color: var(--ink); }
 }
 
 .cover-letter{
-  padding:0;
+  padding:48px;
 }
 
 /* Pager controls */


### PR DESCRIPTION
## Summary
- Ensure A4 preview containers size themselves to scaled dimensions
- Match cover letter preview spacing and 48px padding to downloaded PDF
- Split cover letter text into paragraphs for consistent formatting

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be290766b08329b7def449cc432b64