### PR TITLE
Fix PDF preview accuracy and improve lightbox zoom

### DIFF
--- a/components/ui/LightboxModal.jsx
+++ b/components/ui/LightboxModal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 export default function LightboxModal({ open, onClose, children, onPrev, onNext, canPrev, canNext, pageLabel }) {
   const [scale, setScale] = useState(1);
+  const [fitScale, setFitScale] = useState(1);
 
   useEffect(() => {
     if (!open) return;
@@ -9,7 +10,9 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
     function updateScale() {
       const vw = window.innerWidth - 32;
       const vh = window.innerHeight - 32;
-      setScale(Math.min(vw / 794, vh / 1123, 1));
+      const s = Math.min(vw / 794, vh / 1123, 1);
+      setFitScale(s);
+      setScale(s);
     }
 
     updateScale();
@@ -30,10 +33,22 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
 
   if (!open) return null;
 
+  function toggleZoom(e) {
+    e.stopPropagation();
+    setScale(s => (s === 1 ? fitScale : 1));
+  }
+
+  function stop(e) {
+    e.stopPropagation();
+  }
+
   return (
-    <div className="fixed inset-0 z-[100] bg-black/80 flex items-center justify-center">
+    <div
+      className="fixed inset-0 z-[100] bg-black/80 flex items-center justify-center"
+      onClick={onClose}
+    >
       <button
-        onClick={onClose}
+        onClick={e => { stop(e); onClose(); }}
         className="absolute top-4 right-4 text-white/90 text-xl px-3 py-1 rounded hover:bg-white/10"
         aria-label="Close"
       >
@@ -41,7 +56,7 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
       </button>
       {canPrev && (
         <button
-          onClick={onPrev}
+          onClick={e => { stop(e); onPrev(); }}
           className="absolute left-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10"
           aria-label="Previous"
         >
@@ -50,7 +65,7 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
       )}
       {canNext && (
         <button
-          onClick={onNext}
+          onClick={e => { stop(e); onNext(); }}
           className="absolute right-4 top-1/2 -translate-y-1/2 text-white/90 text-2xl px-3 py-2 rounded hover:bg-white/10"
           aria-label="Next"
         >
@@ -60,6 +75,7 @@ export default function LightboxModal({ open, onClose, children, onPrev, onNext,
       <div
         className="relative bg-white shadow-2xl"
         style={{ width: 794 * scale, height: 1123 * scale }}
+        onClick={toggleZoom}
       >
         <div style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}>{children}</div>
       </div>

--- a/pages/results.js
+++ b/pages/results.js
@@ -43,7 +43,6 @@ export default function ResultsPage(){
 
   useEffect(() => {
     if (!result) return;
-    const pageHeight = 1123;
     const off = document.createElement('div');
     off.className = `paper ${atsMode ? 'ats-mode' : ''}`;
     Object.entries(styleVars).forEach(([k, v]) => off.style.setProperty(k, v));
@@ -52,6 +51,7 @@ export default function ResultsPage(){
     off.style.pointerEvents = 'none';
     off.style.left = '-10000px';
     document.body.appendChild(off);
+    const pageHeight = off.getBoundingClientRect().height;
     const root = createRoot(off);
     root.render(<TemplateComp data={result.resumeData} />);
     requestAnimationFrame(() => {
@@ -61,7 +61,9 @@ export default function ResultsPage(){
       let start = 0;
       while (start < total) {
         let end = start + pageHeight;
-        const crossing = items.find(el => el.offsetTop < end && (el.offsetTop + el.offsetHeight) > end);
+        const crossing = items.find(
+          el => el.offsetTop < end && (el.offsetTop + el.offsetHeight) > end
+        );
         if (crossing && crossing.offsetTop > start) {
           end = crossing.offsetTop;
         }
@@ -76,6 +78,8 @@ export default function ResultsPage(){
         </div>
       ));
       setResumePages(arr);
+      setPage(p => Math.min(p, arr.length - 1));
+      setRIndex(i => Math.min(i, arr.length - 1));
       root.unmount();
       document.body.removeChild(off);
     });
@@ -124,7 +128,7 @@ export default function ResultsPage(){
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="View and export your tailored CV and cover letter with responsive A4 display, side navigation controls, seamless multi-page downloads, customizable templates, themes, density, and ATS-friendly mode."
+          content="Accurately preview and export your tailored CV and cover letter with responsive A4 display, full-screen zoom, side navigation controls, seamless multi-page downloads, customizable templates, themes, density, and ATS-friendly mode."
         />
       </Head>
       <MainShell


### PR DESCRIPTION
## Summary
- compute page height dynamically so on-screen preview matches exported PDF and keep navigation index in range when density changes
- allow full-screen previews to toggle zoom on click and close when clicking outside
- refresh results page meta description for SEO

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be2bdb401c83298ff24c8195ea32ff