### PR TITLE
Export preview HTML to PDF with Puppeteer

### DIFF
--- a/components/export/downloadPdfFromHtml.js
+++ b/components/export/downloadPdfFromHtml.js
@@ -1,0 +1,20 @@
+export async function downloadPdfFromHtml(htmlString, filename = "document.pdf") {
+  const res = await fetch("/api/export-pdf", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ html: htmlString })
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error("Export failed: " + t);
+  }
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "openai": "^4.0.0",
         "pdf-parse": "^1.1.1",
         "pdfreader": "^3.0.5",
+        "puppeteer": "^23.4.0",
         "puppeteer-core": "^23.4.0",
         "react": "latest",
         "react-dom": "latest",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-hook-form": "^7.51.3",
     "@hookform/resolvers": "^3.3.2",
     "framer-motion": "^11.0.12",
+    "puppeteer": "^23.4.0",
     "puppeteer-core": "^23.4.0",
     "chrome-aws-lambda": "^10.1.0"
   },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -276,3 +276,12 @@ html,body{ background: var(--bg); color: var(--ink); }
   .workspace{ grid-template-columns: 1fr; } /* still stacks on small screens only */
 }
 /* ==== /Side-by-side fit-to-width A4 previews ==== */
+
+@page {
+  size: A4;
+  margin: 20mm;
+}
+@media print {
+  body { -webkit-print-color-adjust: exact; color-adjust: exact; }
+  .no-print { display: none !important; }
+}


### PR DESCRIPTION
## Summary
- add puppeteer dependency and API route for Chromium-based PDF rendering
- expose a helper to send preview HTML to the new API and download the PDF
- capture resume and cover letter previews via stable IDs and wire buttons to new export flow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be321f4520832997fa220e25787b87