### PR TITLE
Fix PDF export scaling to true A4 size

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -99,7 +99,7 @@ export default function ResultsPage(){
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           ${cssLinks}
           <style>
-            @page { size: A4; margin: 20mm; }
+            @page { size: A4; margin: 0; }
             @media print { body{ -webkit-print-color-adjust: exact; color-adjust: exact; } }
           </style>
         </head>
@@ -135,11 +135,23 @@ export default function ResultsPage(){
   }
 
   function ResumePreviewWrapper({ children }) {
-    return <div id="resume-preview"><ResponsiveA4Preview>{children}</ResponsiveA4Preview></div>;
+    return (
+      <div id="resume-preview">
+        <div id="print-root">
+          <ResponsiveA4Preview>{children}</ResponsiveA4Preview>
+        </div>
+      </div>
+    );
   }
 
   function CoverPreviewWrapper({ children }) {
-    return <div id="cover-preview"><ResponsiveA4Preview>{children}</ResponsiveA4Preview></div>;
+    return (
+      <div id="cover-preview">
+        <div id="print-root">
+          <ResponsiveA4Preview>{children}</ResponsiveA4Preview>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -285,3 +285,30 @@ html,body{ background: var(--bg); color: var(--ink); }
   body { -webkit-print-color-adjust: exact; color-adjust: exact; }
   .no-print { display: none !important; }
 }
+@page {
+  size: A4;            /* real A4 */
+  margin: 0;           /* margins will be handled by the page content itself */
+}
+
+/* When printing or when we build HTML for Puppeteer, kill preview scaling */
+@media print {
+  /* Nuke any transform-based scaling inside the exported subtree */
+  #print-root [style*="transform"] {
+    transform: none !important;
+  }
+  /* Ensure our A4 inner page still has its true size */
+  #print-root .a4-scope {
+    width: 794px !important;
+    height: 1123px !important;
+  }
+  /* Avoid global max-width rules collapsing content */
+  #print-root .a4-scope img,
+  #print-root .a4-scope canvas,
+  #print-root .a4-scope svg,
+  #print-root .a4-scope iframe,
+  #print-root .a4-scope video {
+    max-width: none !important;
+    width: auto;
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- disable preview scaling during print with new #print-root CSS overrides
- export PDFs using CSS-driven page size without extra margins
- wrap resume and cover previews in #print-root containers for accurate export

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be3599199c832994d1a821ef87fd80