### PR TITLE
Fix PDF export scaling and enforce A4

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -312,3 +312,22 @@ html,body{ background: var(--bg); color: var(--ink); }
     height: auto;
   }
 }
+
+@page { size: A4; margin: 0; }
+@media print {
+  #print-root [style*="transform"] { transform: none !important; }  /* kill preview scaling */
+  #print-root [style*="zoom"] { zoom: 1 !important; }               /* just in case */
+  #print-root .a4-scope {
+    width: 794px !important;    /* A4 @ ~96dpi */
+    height: 1123px !important;
+  }
+  #print-root .a4-scope img,
+  #print-root .a4-scope canvas,
+  #print-root .a4-scope svg,
+  #print-root .a4-scope iframe,
+  #print-root .a4-scope video {
+    max-width: none !important;
+    width: auto;
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Normalize PDF export by emulating print media and trusting CSS page size in Puppeteer.
- Add print CSS to enforce true A4 dimensions and strip preview transforms/zoom.
- Clone DOM for export, removing transforms/zoom and ensuring `#print-root` wrapper for accurate output.

## Testing
- ⚠️ `npm test` (missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68be36e57f4083298b3449aaf1f96d8f