### PR TITLE
Ensure PDF export matches on-screen styling

### DIFF
--- a/components/layout/MainShell.jsx
+++ b/components/layout/MainShell.jsx
@@ -1,7 +1,7 @@
 export default function MainShell({ left, right }) {
   return (
     <div className="max-w-[1360px] mx-auto p-4 lg:flex gap-6">
-      <aside className="lg:w-80 w-full lg:sticky lg:top-4 mb-6 lg:mb-0">{left}</aside>
+      <aside data-app-chrome className="lg:w-80 w-full lg:sticky lg:top-4 mb-6 lg:mb-0">{left}</aside>
       <div className="flex-1">{right}</div>
     </div>
   );

--- a/pages/api/export-pdf.js
+++ b/pages/api/export-pdf.js
@@ -2,11 +2,14 @@ export const config = { api: { bodyParser: { sizeLimit: "3mb" } } };
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
   const puppeteer = (await import("puppeteer")).default;
-  const { html } = req.body || {};
-  if (!html || typeof html !== "string" || html.length < 50) {
-    return res.status(400).json({ error: "Missing or invalid HTML" });
-  }
+  const { data, doc = "resume" } = req.body || {}; // data = the object you store in localStorage["resumeResult"]
+
+  const origin =
+    req.headers.origin ||
+    process.env.PUBLIC_ORIGIN ||
+    "http://localhost:3000";
 
   let browser;
   try {
@@ -15,23 +18,34 @@ export default async function handler(req, res) {
       args: ["--no-sandbox", "--disable-setuid-sandbox"]
     });
     const page = await browser.newPage();
-    await page.emulateMediaType("print"); // ensure print CSS applies
-    await page.setContent(html, { waitUntil: "networkidle0" });
 
+    // 1) Bootstrap an origin context so we can set localStorage for that origin.
+    await page.goto(origin, { waitUntil: "domcontentloaded" });
+
+    // 2) Inject the same data the UI uses
+    await page.evaluate((payload) => {
+      try { localStorage.setItem("resumeResult", JSON.stringify(payload)); } catch (e) {}
+    }, data || null);
+
+    // 3) Navigate to the real results page in print mode (loads Tailwind + fonts)
+    const url = `${origin}/results?print=1&doc=${encodeURIComponent(doc)}`;
+    await page.goto(url, { waitUntil: "networkidle0" });
+
+    // 4) Use print media and trust CSS @page sizing
+    await page.emulateMediaType("print");
     const pdf = await page.pdf({
       printBackground: true,
-      preferCSSPageSize: true,        // trust @page { size: A4 }
+      preferCSSPageSize: true,
       margin: { top: 0, right: 0, bottom: 0, left: 0 },
       scale: 1
     });
 
     await browser.close();
     res.setHeader("Content-Type", "application/pdf");
-    res.setHeader("Content-Disposition", 'attachment; filename="document.pdf"');
+    res.setHeader("Content-Disposition", `attachment; filename="${doc}.pdf"`);
     return res.send(pdf);
   } catch (e) {
     try { if (browser) await browser.close(); } catch {}
     return res.status(500).json({ error: String(e?.message || e) });
   }
 }
-

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -331,3 +331,20 @@ html,body{ background: var(--bg); color: var(--ink); }
     height: auto;
   }
 }
+@page { size: A4; margin: 0; }
+@media print {
+  html.print-mode body { -webkit-print-color-adjust: exact; color-adjust: exact; }
+  /* Hide app chrome/controls in print */
+  [data-app-chrome], .no-print { display: none !important; }
+
+  /* Disable preview scaling in print */
+  #print-root [style*="transform"] { transform: none !important; }
+  #print-root [style*="zoom"] { zoom: 1 !important; }
+
+  /* Ensure inner A4 box remains true size; your preview already uses .a4-scope */
+  #print-root .a4-scope { width: 794px !important; height: 1123px !important; }
+  #print-root .a4-scope img, #print-root .a4-scope canvas, #print-root .a4-scope svg,
+  #print-root .a4-scope iframe, #print-root .a4-scope video {
+    max-width: none !important; width: auto; height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Append print-mode styles to match A4 layout, hide app chrome, and disable preview scaling during print
- Tag control column as app chrome and detect `?print` URL param to toggle print mode on the results page
- Replace HTML-based PDF export with a route that loads the real page via Puppeteer and exports resume or cover letter PDFs

## Testing
- `npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_68be38ab7b388329b6ee49cfc2b8b972