### PR TITLE
fix: guard container width hook against null refs

### DIFF
--- a/components/ui/useContainerWidth.js
+++ b/components/ui/useContainerWidth.js
@@ -10,7 +10,7 @@ export default function useContainerWidth(ref, deps = []) {
         if (!ref.current) return;
         const ro = new ResizeObserver(entries => {
           for (const e of entries) {
-            const cw = e.contentRect?.width || ref.current.offsetWidth || 0;
+            const cw = e.contentRect?.width ?? ref.current?.offsetWidth ?? 0;
             width = cw;
             setW(cw);
           }


### PR DESCRIPTION
## Summary
- avoid accessing `offsetWidth` when ref is null in `useContainerWidth`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf069e3ba48329868efe7ac4a85702