### PR TITLE
Align PDF export with on-screen preview

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -221,12 +221,15 @@ html,body{ background: var(--bg); color: var(--ink); }
   height:297mm;
   box-sizing:border-box;
   background:#fff;
-  border:1px solid var(--border);
-  border-radius:8px;
-  box-shadow:0 1px 3px rgba(0,0,0,0.08);
   overflow:hidden;
   padding:1in;
   position:relative;
+}
+
+.print-mode .paper{
+  box-shadow:none;
+  border:0;
+  border-radius:0;
 }
 
 .avoid-break {

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -57,8 +57,6 @@
 .sidebarMain { position: relative; }
 .sidebarMain::before { content:""; position:absolute; left:-9px; top:0; bottom:0; width:1px; background: var(--rule); }
 
-@page { margin: 1in; }
-
 @media print {
 
   body { background: #fff; }


### PR DESCRIPTION
## Summary
- remove borders and drop shadows from printable page container so PDF output mirrors the preview margins
- drop `@page` margin rule to rely on internal padding for A4 sizing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c069731004832993c466350a69ee5f