### PR TITLE
Align PDF export with on-screen preview

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -112,7 +112,7 @@ export default function ResultsPage(){
     const head = document.head.cloneNode(true);
     head.querySelectorAll('script').forEach(s => s.remove());
     const pagesHtml = resumePages.map(p => renderToStaticMarkup(p)).join('');
-    const html = `<!doctype html><html><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
+    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
     try {
       await downloadPdfFromHtml(html, 'resume.pdf', 'resume');
     } catch (e) {
@@ -125,7 +125,7 @@ export default function ResultsPage(){
     const head = document.head.cloneNode(true);
     head.querySelectorAll('script').forEach(s => s.remove());
     const pagesHtml = coverPages.map(p => renderToStaticMarkup(p)).join('');
-    const html = `<!doctype html><html><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
+    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
     try {
       await downloadPdfFromHtml(html, 'cover-letter.pdf', 'cover');
     } catch (e) {
@@ -167,7 +167,7 @@ export default function ResultsPage(){
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="Accurately preview and export your tailored CV and cover letter with responsive A4 display, consistent page margins, multi-page PDF export, scrollable full-screen zoom, arrow navigation for multi-page previews, seamless downloads, customizable templates, themes, density, and ATS-friendly mode."
+          content="Accurately preview and export your tailored CV and cover letter with responsive A4 display, exact PDF replication, consistent page margins, scrollable full-screen zoom, arrow navigation for multi-page previews, seamless downloads, customizable templates, themes, density, and ATS-friendly mode."
         />
       </Head>
       <MainShell

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -221,12 +221,20 @@ html,body{ background: var(--bg); color: var(--ink); }
   height:297mm;
   box-sizing:border-box;
   background:#fff;
-  border:1px solid var(--border);
-  border-radius:8px;
-  box-shadow:0 1px 3px rgba(0,0,0,0.08);
   overflow:hidden;
   padding:1in;
   position:relative;
+}
+
+.print-mode .paper{
+  box-shadow:none;
+  border:0;
+  border-radius:0;
+}
+
+@media print {
+  .paper { page-break-after: always; }
+  .paper:last-child { page-break-after: auto; }
 }
 
 .avoid-break {

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -57,8 +57,6 @@
 .sidebarMain { position: relative; }
 .sidebarMain::before { content:""; position:absolute; left:-9px; top:0; bottom:0; width:1px; background: var(--rule); }
 
-@page { margin: 1in; }
-
 @media print {
 
   body { background: #fff; }


### PR DESCRIPTION
## Summary
- add print-specific page break rules so each exported sheet renders separately
- ensure generated HTML enables print-mode on the `<html>` element for accurate margins
- update results page SEO description for improved accuracy

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c069731004832993c466350a69ee5f