### PR TITLE
fix pdf duplication and margins

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { renderToStaticMarkup } from 'react-dom/server';
 import Head from 'next/head';
 import MainShell from '../components/layout/MainShell';
 import ControlsPanel from '../components/ui/ControlsPanel';
@@ -108,11 +107,14 @@ export default function ResultsPage(){
   const coverPages = [coverPage];
 
   async function downloadResumePdf() {
-    if (!resumePages.length) return alert('No resume content to export');
+    const rootEl = document.getElementById('resume-preview');
+    const papers = rootEl ? rootEl.querySelectorAll('.paper') : [];
+    if (!papers.length) return alert('No resume content to export');
     const head = document.head.cloneNode(true);
     head.querySelectorAll('script').forEach(s => s.remove());
-    const pagesHtml = resumePages.map(p => renderToStaticMarkup(p)).join('');
-    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
+    const pagesHtml = Array.from(papers).map(el => el.outerHTML).join('');
+    const extra = `@page{margin:0;}body{margin:0}.paper{padding-bottom:calc(1in + 0.5in);overflow:hidden} .paper{page-break-after:always;} .paper:last-child{page-break-after:auto;}`;
+    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}<style>${extra}</style></head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
     try {
       await downloadPdfFromHtml(html, 'resume.pdf', 'resume');
     } catch (e) {
@@ -121,11 +123,14 @@ export default function ResultsPage(){
   }
 
   async function downloadCoverPdf() {
-    if (!coverPages.length) return alert('No cover letter content to export');
+    const rootEl = document.getElementById('cover-preview');
+    const papers = rootEl ? rootEl.querySelectorAll('.paper') : [];
+    if (!papers.length) return alert('No cover letter content to export');
     const head = document.head.cloneNode(true);
     head.querySelectorAll('script').forEach(s => s.remove());
-    const pagesHtml = coverPages.map(p => renderToStaticMarkup(p)).join('');
-    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}</head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
+    const pagesHtml = Array.from(papers).map(el => el.outerHTML).join('');
+    const extra = `@page{margin:0;}body{margin:0}.paper{padding-bottom:calc(1in + 0.5in);overflow:hidden} .paper{page-break-after:always;} .paper:last-child{page-break-after:auto;}`;
+    const html = `<!doctype html><html class="print-mode"><head><base href="${location.origin}">${head.innerHTML}<style>${extra}</style></head><body class="print-mode"><div id="print-root">${pagesHtml}</div></body></html>`;
     try {
       await downloadPdfFromHtml(html, 'cover-letter.pdf', 'cover');
     } catch (e) {
@@ -167,7 +172,7 @@ export default function ResultsPage(){
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="Accurately preview and export your tailored CV and cover letter with responsive A4 display, exact PDF replication, consistent page margins, scrollable full-screen zoom, arrow navigation for multi-page previews, seamless downloads, customizable templates, themes, density, and ATS-friendly mode."
+          content="Accurately preview and export your tailored CV and cover letter with responsive A4 display, duplicate-free PDF replication, consistent page margins with extra bottom spacing, scrollable full-screen zoom, arrow navigation for multi-page previews, seamless downloads, customizable templates, themes, density, and ATS-friendly mode."
         />
       </Head>
       <MainShell


### PR DESCRIPTION
## Summary
- clone resume and cover letter DOM to generate PDFs, eliminating duplicated sections and preserving 0.5in bottom margin per page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c07656faf48329a6bcbeb56ab754e5