### PR TITLE
Fix PDF page duplication and stabilize pagination

### DIFF
--- a/components/pdf/CenteredPdf.jsx
+++ b/components/pdf/CenteredPdf.jsx
@@ -59,11 +59,11 @@ function Header({ data }) {
         <View style={styles.linkRow}>
           {contacts.map((c, i) =>
             c.startsWith("http") ? (
-              <Link key={i} src={c} style={styles.linkText}>
+              <Link key={`${c}-${i}`} src={c} style={styles.linkText}>
                 {c}
               </Link>
             ) : (
-              <Text key={i} style={{ marginRight: 8 }}>
+              <Text key={`${c}-${i}`} style={{ marginRight: 8 }}>
                 {c}
               </Text>
             )
@@ -86,7 +86,7 @@ function Skills({ data }) {
       <SectionTitle>Skills</SectionTitle>
       <View style={styles.pillWrap}>
         {data.skills.map((s, i) => (
-          <Text key={i} style={styles.pill}>
+          <Text key={`${s}-${i}`} style={styles.pill}>
             {String(s)}
           </Text>
         ))}
@@ -104,7 +104,7 @@ function Experience({ data }) {
       {xp.map((x, i) => {
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
-          <View key={i} wrap={false}>
+          <View key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} wrap={false}>
             {x.company ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
             ) : null}
@@ -114,7 +114,7 @@ function Experience({ data }) {
 
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
-                <Text key={j} style={styles.li}>
+                <Text key={`${b}-${j}`} style={styles.li}>
                   • {String(b)}
                 </Text>
               ))}
@@ -136,7 +136,7 @@ function Education({ data }) {
         const dates = [e.start, e.end].filter(Boolean).join(" – ");
         const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
-          <View key={i} wrap={false} style={{ marginBottom: 4 }}>
+          <View key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} wrap={false} style={{ marginBottom: 4 }}>
             {e.school ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             ) : null}

--- a/components/pdf/ClassicPdf.jsx
+++ b/components/pdf/ClassicPdf.jsx
@@ -71,11 +71,11 @@ function Header({ data }) {
         <View style={styles.linkRow}>
           {contacts.map((c, i) =>
             c.startsWith("http") ? (
-              <Link key={i} src={c} style={styles.linkText}>
+              <Link key={`${c}-${i}`} src={c} style={styles.linkText}>
                 {c}
               </Link>
             ) : (
-              <Text key={i} style={{ marginRight: 8 }}>
+              <Text key={`${c}-${i}`} style={{ marginRight: 8 }}>
                 {c}
               </Text>
             )
@@ -98,7 +98,7 @@ function Skills({ data }) {
       <SectionTitle>Skills</SectionTitle>
       <View style={styles.pillWrap}>
         {data.skills.map((s, i) => (
-          <Text key={i} style={styles.pill}>
+          <Text key={`${s}-${i}`} style={styles.pill}>
             {String(s)}
           </Text>
         ))}
@@ -116,7 +116,7 @@ function Experience({ data }) {
       {xp.map((x, i) => {
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
-          <View key={i} wrap={false}>
+          <View key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} wrap={false}>
             {x.company ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
             ) : null}
@@ -125,7 +125,7 @@ function Experience({ data }) {
 
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
-                <Text key={j} style={styles.li}>
+                <Text key={`${b}-${j}`} style={styles.li}>
                   • {String(b)}
                 </Text>
               ))}
@@ -147,7 +147,7 @@ function Education({ data }) {
         const dates = [e.start, e.end].filter(Boolean).join(" – ");
         const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
-          <View key={i} wrap={false} style={{ marginBottom: 4 }}>
+          <View key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} wrap={false} style={{ marginBottom: 4 }}>
             {e.school ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             ) : null}

--- a/components/pdf/CoverLetterPdf.jsx
+++ b/components/pdf/CoverLetterPdf.jsx
@@ -16,7 +16,7 @@ export default function CoverLetterPdf({ text }) {
     <Document>
       <Page size="A4" style={styles.page}>
         {body.split(/\n+/).map((line, i) => (
-          <Text key={i} style={styles.para}>{line}</Text>
+          <Text key={`${line}-${i}`} style={styles.para}>{line}</Text>
         ))}
       </Page>
     </Document>

--- a/components/pdf/SidebarPdf.jsx
+++ b/components/pdf/SidebarPdf.jsx
@@ -68,7 +68,7 @@ function Skills({ data }) {
     <View>
       <Text style={[styles.h2, { marginTop: 0 }]}>Skills</Text>
       {data.skills.map((s, i) => (
-        <Text key={i} style={styles.pill}>
+        <Text key={`${s}-${i}`} style={styles.pill}>
           {String(s)}
         </Text>
       ))}
@@ -86,7 +86,7 @@ function Education({ data }) {
         const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
         const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
-          <View key={i} style={{ marginBottom: 6 }}>
+          <View key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} wrap={false} style={{ marginBottom: 6 }}>
             <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
             {dateRange ? <Text style={styles.muted}>{dateRange}</Text> : null}
@@ -117,7 +117,7 @@ function Experience({ data }) {
       {xp.map((x, i) => {
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
-          <View key={i} wrap={false}>
+          <View key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} wrap={false}>
             {x.company ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
             ) : null}
@@ -126,7 +126,7 @@ function Experience({ data }) {
 
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
-                <Text key={j} style={styles.li}>
+                <Text key={`${b}-${j}`} style={styles.li}>
                   • {String(b)}
                 </Text>
               ))}

--- a/components/pdf/TwoColPdf.jsx
+++ b/components/pdf/TwoColPdf.jsx
@@ -63,7 +63,7 @@ function Skills({ data }) {
     <View>
       <Text style={[styles.h2, { marginTop: 0 }]}>Skills</Text>
       {data.skills.map((s, i) => (
-        <Text key={i} style={styles.pill}>
+        <Text key={`${s}-${i}`} style={styles.pill}>
           {String(s)}
         </Text>
       ))}
@@ -81,7 +81,7 @@ function Education({ data }) {
         const dateRange = [e.start, e.end].filter(Boolean).join(" – ");
         const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
         return (
-          <View key={i} style={{ marginBottom: 6 }}>
+          <View key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} wrap={false} style={{ marginBottom: 6 }}>
             <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{e.school}</Text>
             {detail ? <Text style={styles.muted}>{detail}</Text> : null}
             {dateRange ? <Text style={styles.muted}>{dateRange}</Text> : null}
@@ -112,7 +112,7 @@ function Experience({ data }) {
       {xp.map((x, i) => {
         const dates = [x.start, x.end || "Present"].filter(Boolean).join(" – ");
         return (
-          <View key={i} wrap={false}>
+          <View key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} wrap={false}>
             {x.company ? (
               <Text style={{ fontFamily: "InterBold", fontWeight: 700 }}>{x.company}</Text>
             ) : null}
@@ -121,7 +121,7 @@ function Experience({ data }) {
 
             <View style={styles.ul}>
               {(Array.isArray(x.bullets) ? x.bullets : []).map((b, j) => (
-                <Text key={j} style={styles.li}>
+                <Text key={`${b}-${j}`} style={styles.li}>
                   • {String(b)}
                 </Text>
               ))}

--- a/components/templates/Centered.jsx
+++ b/components/templates/Centered.jsx
@@ -25,13 +25,13 @@ export default function Centered({ data = {} }) {
       {skills.length > 0 && (
         <>
           <h2>Skills</h2>
-          <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+          <div>{skills.map((s, i) => <span className="pill" key={`${s}-${i}`}>{s}</span>)}</div>
         </>
       )}
 
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
-        <section key={i} className="avoid-break">
+        <section key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} className="avoid-break">
           {x.company && <strong>{x.company}</strong>}
           {x.role && <div>{x.role}</div>}
           {(x.start || x.end != null) && (
@@ -40,14 +40,14 @@ export default function Centered({ data = {} }) {
           )}
           {x.location && <div className="muted">{x.location}</div>}
           {Array.isArray(x.bullets) && x.bullets.length > 0 && (
-            <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+            <ul>{x.bullets.map((b, j) => <li key={`${b}-${j}`}>{b}</li>)}</ul>
           )}
         </section>
       ))}
 
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
-        <div key={i}>
+        <div key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} className="avoid-break">
           {e.school && <strong>{e.school}</strong>}
           {(e.degree || e.grade) && (
             <div>{[e.degree, e.grade].filter(Boolean).join(" — ")}</div>

--- a/components/templates/Classic.jsx
+++ b/components/templates/Classic.jsx
@@ -25,13 +25,13 @@ export default function Classic({ data = {} }) {
       {skills.length > 0 && (
         <>
           <h2>Skills</h2>
-          <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+          <div>{skills.map((s, i) => <span className="pill" key={`${s}-${i}`}>{s}</span>)}</div>
         </>
       )}
 
       {exp.length > 0 && <h2>Experience</h2>}
       {exp.map((x, i) => (
-        <section key={i} className="avoid-break">
+        <section key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} className="avoid-break">
           {x.company && <strong>{x.company}</strong>}
           {x.role && <div>{x.role}</div>}
           {(x.start || x.end != null) && (
@@ -40,14 +40,14 @@ export default function Classic({ data = {} }) {
           )}
           {x.location && <div className="muted">{x.location}</div>}
           {Array.isArray(x.bullets) && x.bullets.length > 0 && (
-            <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+            <ul>{x.bullets.map((b, j) => <li key={`${b}-${j}`}>{b}</li>)}</ul>
           )}
         </section>
       ))}
 
       {edu.length > 0 && <h2>Education</h2>}
       {edu.map((e, i) => (
-        <div key={i}>
+        <div key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} className="avoid-break">
           {e.school && <strong>{e.school}</strong>}
           {(e.degree || e.grade) && (
             <div>{[e.degree, e.grade].filter(Boolean).join(" — ")}</div>

--- a/components/templates/Modern.jsx
+++ b/components/templates/Modern.jsx
@@ -49,7 +49,7 @@ export default function Modern({ data = {} }) {
                 <h2 className="modern-h2">Skills</h2>
                 <ul className="modern-skill-list">
                   {skills.map((s, i) => (
-                    <li key={i} className="modern-skill">{s}</li>
+                    <li key={`${s}-${i}`} className="modern-skill">{s}</li>
                   ))}
                 </ul>
               </section>
@@ -61,7 +61,7 @@ export default function Modern({ data = {} }) {
                 <h2 className="modern-h2">Education</h2>
                 <ul className="modern-edu-list">
                   {education.map((e, i) => (
-                    <li key={i} className="modern-edu-item avoid-break">
+                    <li key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} className="modern-edu-item avoid-break">
                       <div className="modern-edu-line">
                         <span className="modern-edu-school">{e.school}</span>
                         {e.degree ? <span className="modern-edu-degree"> — {e.degree}</span> : null}
@@ -83,7 +83,7 @@ export default function Modern({ data = {} }) {
               <h2 className="modern-h2">Experience</h2>
               <ul className="modern-exp-list">
                 {(experience || []).map((x, i) => (
-                  <li key={i} className="modern-exp-item avoid-break">
+                  <li key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} className="modern-exp-item avoid-break">
                     <div className="modern-exp-head">
                       <div className="modern-exp-role">
                         <span className="modern-exp-company">{x.company}</span>
@@ -98,7 +98,7 @@ export default function Modern({ data = {} }) {
                     {(x.bullets || []).length ? (
                       <ul className="modern-bullets">
                         {x.bullets.map((b, j) => (
-                          <li key={j} className="modern-bullet">{b}</li>
+                          <li key={`${b}-${j}`} className="modern-bullet">{b}</li>
                         ))}
                       </ul>
                     ) : null}

--- a/components/templates/Sidebar.jsx
+++ b/components/templates/Sidebar.jsx
@@ -23,7 +23,7 @@ export default function Sidebar({ data = {} }) {
         {skills.length > 0 && (
           <>
             <h2>Skills</h2>
-            <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+            <div>{skills.map((s, i) => <span className="pill" key={`${s}-${i}`}>{s}</span>)}</div>
           </>
         )}
 
@@ -36,7 +36,7 @@ export default function Sidebar({ data = {} }) {
                 .join(" – ");
               const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
               return (
-                <div key={i}>
+                <div key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} className="avoid-break">
                   <strong>{e.school}</strong>
                   {detail && <div>{detail}</div>}
                   {dateRange && <div className="muted">{dateRange}</div>}
@@ -52,7 +52,7 @@ export default function Sidebar({ data = {} }) {
         {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
-          <section key={i} className="avoid-break">
+          <section key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} className="avoid-break">
             {x.company && <strong>{x.company}</strong>}
             {x.role && <div>{x.role}</div>}
             {(x.start || x.end != null) && (
@@ -61,7 +61,7 @@ export default function Sidebar({ data = {} }) {
             )}
             {x.location && <div className="muted">{x.location}</div>}
             {Array.isArray(x.bullets) && x.bullets.length > 0 && (
-              <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+              <ul>{x.bullets.map((b, j) => <li key={`${b}-${j}`}>{b}</li>)}</ul>
             )}
           </section>
         ))}

--- a/components/templates/TwoCol.jsx
+++ b/components/templates/TwoCol.jsx
@@ -23,7 +23,7 @@ export default function TwoCol({ data = {} }) {
         {skills.length > 0 && (
           <>
             <h2>Skills</h2>
-            <div>{skills.map((s, i) => <span className="pill" key={i}>{s}</span>)}</div>
+            <div>{skills.map((s, i) => <span className="pill" key={`${s}-${i}`}>{s}</span>)}</div>
           </>
         )}
 
@@ -36,7 +36,7 @@ export default function TwoCol({ data = {} }) {
                 .join(" – ");
               const detail = [e.degree, e.grade].filter(Boolean).join(" • ");
               return (
-                <div key={i}>
+                <div key={`${e.school}-${e.degree}-${e.start}-${e.end}-${i}`} className="avoid-break">
                   <strong>{e.school}</strong>
                   {detail && <div>{detail}</div>}
                   {dateRange && <div className="muted">{dateRange}</div>}
@@ -52,7 +52,7 @@ export default function TwoCol({ data = {} }) {
         {data.summary && (<><h2>Profile</h2><p>{data.summary}</p></>)}
         {exp.length > 0 && <h2>Experience</h2>}
         {exp.map((x, i) => (
-          <section key={i} className="avoid-break">
+          <section key={`${x.company}-${x.role}-${x.start}-${x.end}-${i}`} className="avoid-break">
             {x.company && <strong>{x.company}</strong>}
             {x.role && <div>{x.role}</div>}
             {(x.start || x.end != null) && (
@@ -61,7 +61,7 @@ export default function TwoCol({ data = {} }) {
             )}
             {x.location && <div className="muted">{x.location}</div>}
             {Array.isArray(x.bullets) && x.bullets.length > 0 && (
-              <ul>{x.bullets.map((b, j) => <li key={j}>{b}</li>)}</ul>
+              <ul>{x.bullets.map((b, j) => <li key={`${b}-${j}`}>{b}</li>)}</ul>
             )}
           </section>
         ))}

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,0 +1,11 @@
+export function dedupeAtBoundary(prev = [], next = []) {
+  if (!Array.isArray(prev) || !Array.isArray(next)) return [prev, next];
+  if (!prev.length || !next.length) return [prev, next];
+  const last = prev[prev.length - 1];
+  const first = next[0];
+  const isEqual = last === first;
+  const deepEqual = !isEqual &&
+    typeof last === 'object' && typeof first === 'object' &&
+    JSON.stringify(last) === JSON.stringify(first);
+  return isEqual || deepEqual ? [prev, next.slice(1)] : [prev, next];
+}

--- a/pages/results.js
+++ b/pages/results.js
@@ -8,6 +8,7 @@ import PageCarousel from '../components/ui/PageCarousel';
 import LightboxModal from '../components/ui/LightboxModal';
 import ResponsiveA4Preview from '../components/ui/ResponsiveA4Preview';
 import { downloadPdfFromHtml } from '../components/export/downloadPdfFromHtml';
+import { dedupeAtBoundary } from '../lib/paginate';
 
 export default function ResultsPage(){
   const [result, setResult] = useState(null);
@@ -78,7 +79,11 @@ export default function ResultsPage(){
         positions.push(start);
         start = end;
       }
-      const arr = positions.map((pos, i) => (
+      const clean = positions.reduce((acc, pos) => {
+        const [prev, next] = dedupeAtBoundary(acc, [pos]);
+        return prev.concat(next);
+      }, []);
+      const arr = clean.map((pos, i) => (
         <div className={`paper ${atsMode ? 'ats-mode' : ''}`} style={styleVars} key={i}>
           <div style={{ position: 'relative', top: -pos }}>
             <TemplateComp data={result.resumeData} />


### PR DESCRIPTION
## Summary
- prevent duplicate resume blocks by deduping pagination offsets
- mark education entries as non-breaking and use deterministic keys across resume templates
- ensure PDF export items in React-PDF templates stay on one page with wrap safeguards

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c07cb12ed8832981169d3f63a90bbb