### PR TITLE
feat(templates): add Modern and rebuild Classic/TwoCol/Sidebar/Centered with shared design system; stabilize pagination; ATS mode; accent theming

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { pdf } from '@react-pdf/renderer';
+import { pdf, PDFViewer } from '@react-pdf/renderer';
 import MainShell from '../components/layout/MainShell';
 import ControlsPanel from '../components/ui/ControlsPanel';
 import ResumePdf from '../components/pdf/ResumePdf';
@@ -97,7 +97,7 @@ export default function ResultsPage() {
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="Preview and download your tailored CV and cover letter as clean PDFs with smart page breaks and zero duplication, displayed side by side with easy controls."
+          content="Preview and download your tailored CV and cover letter as clean PDFs with smart page breaks, zero duplication and no browser toolbars, presented in dark-bordered previews side by side with easy controls."
         />
       </Head>
       <MainShell
@@ -120,14 +120,24 @@ export default function ResultsPage() {
         right={
           <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
             <div id="resume-preview" className="h-[80vh]">
-              {resumeUrl && (
-                <object data={resumeUrl} type="application/pdf" className="w-full h-full" />
-              )}
+              <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
+                <ResumePdf
+                  data={result.resumeData}
+                  accent={accent}
+                  density={density}
+                  atsMode={atsMode}
+                />
+              </PDFViewer>
             </div>
             <div id="cover-preview" className="h-[80vh]">
-              {coverUrl && (
-                <object data={coverUrl} type="application/pdf" className="w-full h-full" />
-              )}
+              <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
+                <CoverLetterPdf
+                  text={result.coverLetter}
+                  accent={accent}
+                  density={density}
+                  atsMode={atsMode}
+                />
+              </PDFViewer>
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary
- hide default browser PDF controls using React-PDF `PDFViewer` and add dark contrast border around previews
- update results page meta description for refined, toolbar-free viewing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0863f5fe88329b7f7bf6d6980a7a5