### PR TITLE
Use PDFViewer for toolbar-free resume preview

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -121,21 +121,24 @@ export default function ResultsPage() {
         right={
           <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
             <div id="resume-preview" className="h-[80vh]">
-              {resumeUrl && (
-                <iframe
-                  src={`${resumeUrl}#toolbar=0&navpanes=0&scrollbar=0`}
-                  className="w-full h-full border border-gray-800"
+              <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
+                <ResumePdf
+                  data={result.resumeData}
+                  accent={accent}
+                  density={density}
+                  atsMode={atsMode}
                 />
-              )}
+              </PDFViewer>
             </div>
             <div id="cover-preview" className="h-[80vh]">
-              {coverUrl && (
-                <iframe
-                  src={`${coverUrl}#toolbar=0&navpanes=0&scrollbar=0`}
-                  className="w-full h-full border border-gray-800"
+              <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
+                <CoverLetterPdf
+                  text={result.coverLetter}
+                  accent={accent}
+                  density={density}
+                  atsMode={atsMode}
                 />
-              )}
-
+              </PDFViewer>
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary
- Replace iframe previews with @react-pdf/renderer `PDFViewer` and disable the toolbar for clean bordered previews

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c08ba823b483298210c9a96e019b45