### PR TITLE
Embed template HTML/CSS strings via registry

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,17 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  webpack: (config) => {
-    // Treat anything imported with ?raw as a string (no CSS/HTML loaders)
-    config.module.rules.push({
-      resourceQuery: /raw/,   // enables `import x from './file.css?raw'`
-      type: 'asset/source'
-    })
-    // Also allow plain .html files (without ?raw) to be imported as strings if needed
-    config.module.rules.push({
-      test: /\.html$/i,
-      type: 'asset/source'
-    })
-    return config
-  }
-}
+const nextConfig = {}
+
 module.exports = nextConfig

--- a/pages/api/pdf.js
+++ b/pages/api/pdf.js
@@ -1,7 +1,7 @@
-import { getTemplate } from '../../templates'
-import { toTemplateModel } from '../../lib/templateModel'
-import { renderHtml } from '../../lib/renderHtmlTemplate'
-import { renderReactPdf } from '../../lib/renderReactPdf'
+import { getTemplate } from '@/templates'
+import { toTemplateModel } from '@/lib/templateModel'
+import { renderHtml } from '@/lib/renderHtmlTemplate'
+import { renderReactPdf } from '@/lib/renderReactPdf'
 import puppeteer from 'puppeteer'
 
 export default async function handler(req, res){

--- a/pages/results.js
+++ b/pages/results.js
@@ -4,9 +4,9 @@ import Head from 'next/head';
 import MainShell from '../components/layout/MainShell';
 import ControlsPanel from '../components/ui/ControlsPanel';
 import CoverLetterPdf from '../components/pdf/CoverLetterPdf';
-import { listTemplates, getTemplate } from '../templates';
-import { renderHtml } from '../lib/renderHtmlTemplate';
-import { toTemplateModel } from '../lib/templateModel';
+import { listTemplates, getTemplate } from '@/templates';
+import { renderHtml } from '@/lib/renderHtmlTemplate';
+import { toTemplateModel } from '@/lib/templateModel';
 import { pdf } from '@react-pdf/renderer';
 
 const PDFViewer = dynamic(() => import('@react-pdf/renderer').then(m => m.PDFViewer), { ssr: false });

--- a/scripts/generate-template-registry.mjs
+++ b/scripts/generate-template-registry.mjs
@@ -1,44 +1,45 @@
 import fs from 'fs'
 import path from 'path'
+
 const ROOT = process.cwd()
-const TEMPLATES_DIR = path.join(ROOT, 'templates')
-const OUT = path.join(TEMPLATES_DIR, 'registry.generated.js')
+const TPL_DIR = path.join(ROOT, 'templates')
+const OUT = path.join(TPL_DIR, 'registry.generated.js')
 
-function readJSON(p){ return JSON.parse(fs.readFileSync(p,'utf8')) }
-
-function scan(){
-  if (!fs.existsSync(TEMPLATES_DIR)) fs.mkdirSync(TEMPLATES_DIR)
-  const dirs = fs.readdirSync(TEMPLATES_DIR).filter(d => fs.lstatSync(path.join(TEMPLATES_DIR,d)).isDirectory())
-  const entries = []
-  for (const dir of dirs){
-    const manifestPath = path.join(TEMPLATES_DIR, dir, 'template.json')
+function readMaybe(p) {
+  try { return fs.readFileSync(p, 'utf8') } catch { return '' }
+}
+function scanTemplates() {
+  if (!fs.existsSync(TPL_DIR)) fs.mkdirSync(TPL_DIR)
+  const dirs = fs.readdirSync(TPL_DIR).filter(d => fs.lstatSync(path.join(TPL_DIR, d)).isDirectory())
+  const items = []
+  for (const dir of dirs) {
+    const manifestPath = path.join(TPL_DIR, dir, 'template.json')
     if (!fs.existsSync(manifestPath)) continue
-    const m = readJSON(manifestPath)
+    const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
     if (!m.id || !m.name || !m.engine) continue
-    entries.push({ dir, ...m })
+    const htmlPath = path.join(TPL_DIR, dir, 'template.html')
+    const cssPath  = path.join(TPL_DIR, dir, 'style.css')
+    const html = readMaybe(htmlPath)
+    const css  = readMaybe(cssPath)
+    items.push({
+      id: m.id, name: m.name, engine: m.engine, dir,
+      html, css // may be empty for react-pdf templates
+    })
   }
+  return items
+}
+function emit(items) {
   const lines = []
   lines.push('// AUTO-GENERATED. Do not edit by hand.')
-  for (const e of entries){
-    const safeId = e.id.replace(/[^a-zA-Z0-9_$]/g, '_')
-    if (e.engine === 'react-pdf'){
-      lines.push(`import * as T_${safeId} from './${e.dir}/index.jsx'`)
-    } else {
-      lines.push(`import html_${safeId} from './${e.dir}/template.html?raw'`)
-      lines.push(`import css_${safeId} from './${e.dir}/style.css?raw'`)
-    }
-  }
+  lines.push('// Templates registry with embedded HTML/CSS as strings.')
   lines.push('export const templates = [')
-  for (const e of entries){
-    const safeId = e.id.replace(/[^a-zA-Z0-9_$]/g, '_')
-    if (e.engine === 'react-pdf'){
-      lines.push(`  { id: '${e.id}', name: '${e.name}', engine: 'react-pdf', module: T_${safeId} },`)
-    } else {
-      lines.push(`  { id: '${e.id}', name: '${e.name}', engine: 'html', html: html_${safeId}, css: css_${safeId} },`)
-    }
+  for (const t of items) {
+    // JSON.stringify safely escapes contents as plain JS strings
+    lines.push(`  { id: ${JSON.stringify(t.id)}, name: ${JSON.stringify(t.name)}, engine: ${JSON.stringify(t.engine)}, html: ${JSON.stringify(t.html)}, css: ${JSON.stringify(t.css)} },`)
   }
   lines.push(']')
   fs.writeFileSync(OUT, lines.join('\n'))
-  console.log(`Generated ${OUT} with ${entries.length} template(s).`)
+  console.log(`Generated ${OUT} with ${items.length} template(s).`)
 }
-scan()
+
+emit(scanTemplates())

--- a/templates/index.js
+++ b/templates/index.js
@@ -1,9 +1,19 @@
-export { templates } from './registry.generated'
+import { templates as registryTemplates } from './registry.generated.js'
+import * as T_minimal_reactpdf from './minimal-reactpdf/index.jsx'
+
+const modules = {
+  'minimal-reactpdf': T_minimal_reactpdf,
+}
+
+export const templates = registryTemplates.map(t => (
+  t.engine === 'react-pdf' && modules[t.id]
+    ? { ...t, module: modules[t.id] }
+    : t
+))
 
 export function getTemplate(id) {
   return templates.find(t => t.id === id) || templates[0]
 }
-
 export function listTemplates() {
   return templates.map(t => ({ id: t.id, name: t.name, engine: t.engine }))
 }

--- a/templates/registry.generated.js
+++ b/templates/registry.generated.js
@@ -1,8 +1,6 @@
 // AUTO-GENERATED. Do not edit by hand.
-import html_minimal_html from './minimal-html/template.html?raw'
-import css_minimal_html from './minimal-html/style.css?raw'
-import * as T_minimal_reactpdf from './minimal-reactpdf/index.jsx'
+// Templates registry with embedded HTML/CSS as strings.
 export const templates = [
-  { id: 'minimal-html', name: 'Minimal HTML', engine: 'html', html: html_minimal_html, css: css_minimal_html },
-  { id: 'minimal-reactpdf', name: 'Minimal React-PDF', engine: 'react-pdf', module: T_minimal_reactpdf },
+  { id: "minimal-html", name: "Minimal HTML", engine: "html", html: "<h1>{{name}}</h1>\n<p class=\"meta\">{{label}} • {{email}} • {{phone}} • {{url}}</p>\n<div class=\"section\">\n  <h2>PROFILE</h2>\n  <p>{{summary}}</p>\n</div>\n<div class=\"section\">\n  <h2>EXPERIENCE</h2>\n  {{#experience}}\n  <div style=\"margin-bottom:6pt;\">\n    <div><span class=\"bold\">{{company}}</span> • <span class=\"bold\">{{title}}</span>\n      <span style=\"float:right\" class=\"meta\">{{start}} — {{end}}</span></div>\n    <ul class=\"list\">\n      {{#bullets}}<li>{{.}}</li>{{/bullets}}\n    </ul>\n  </div>\n  {{/experience}}\n</div>\n<div class=\"section\">\n  <h2>EDUCATION</h2>\n  {{#education}}\n    <div><span class=\"bold\">{{institution}}</span> • <span class=\"bold\">{{area}}</span>\n      <span style=\"float:right\" class=\"meta\">{{start}} — {{end}}</span></div>\n  {{/education}}\n</div>\n", css: "body { font-family: Helvetica, Arial, sans-serif; color:#111; }\nh1 { font-size: 20pt; margin:0 0 6pt; }\nh2 { font-size: 11pt; letter-spacing:.5pt; margin:14pt 0 6pt; }\np, li { font-size: 10pt; line-height: 1.35; margin: 0 0 4pt; }\n.section { margin: 10pt 0; }\n.list { padding-left: 12pt; }\n.bold { font-weight: 700; }\n.meta { color:#475569; font-size:9pt; }\n" },
+  { id: "minimal-reactpdf", name: "Minimal React-PDF", engine: "react-pdf", html: "", css: "" },
 ]


### PR DESCRIPTION
## Summary
- Embed template HTML and CSS directly into the generated registry
- Expose templates via pure ESM index with React-PDF module mapping
- Simplify Next.js config and consume template strings for preview and PDF export

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68c0990345188329b6ce7db384846aad