### PR TITLE
feat: unify resume and cover letter previews

### DIFF
--- a/components/PreviewFrame.jsx
+++ b/components/PreviewFrame.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { BlobProvider } from '@react-pdf/renderer';
+
+const A4 = {
+  wpx: 794, // A4 @ 96dpi (screen preview only)
+  hpx: 1123,
+};
+
+// Renders either an HTML document string or a React-PDF <Document/>
+export default function PreviewFrame({ engine, htmlDoc, ReactPdfDoc }) {
+  const style = {
+    width: A4.wpx,
+    height: A4.hpx,
+    border: '0',
+    boxShadow: '0 10px 30px rgba(0,0,0,.15)',
+    background: '#fff',
+  };
+
+  if (engine === 'html') {
+    return <iframe style={style} srcDoc={htmlDoc} />;
+  }
+
+  // React-PDF: use BlobProvider -> iframe with toolbar disabled
+  if (engine === 'react-pdf') {
+    return (
+      <BlobProvider document={ReactPdfDoc}>
+        {({ url, loading, error }) => {
+          if (loading)
+            return (
+              <div style={{ width: A4.wpx, height: A4.hpx, display: 'grid', placeItems: 'center' }}>
+                Rendering…
+              </div>
+            );
+          if (error)
+            return (
+              <div style={{ width: A4.wpx, height: A4.hpx, padding: 16, color: 'crimson' }}>
+                PDF error: {String(error)}
+              </div>
+            );
+          const cleanUrl = url ? url + '#view=FitH&toolbar=0&navpanes=0&scrollbar=0' : '';
+          return <iframe style={style} src={cleanUrl} />;
+        }}
+      </BlobProvider>
+    );
+  }
+
+  return null;
+}

--- a/lib/renderHtmlTemplate.js
+++ b/lib/renderHtmlTemplate.js
@@ -1,19 +1,29 @@
 import Mustache from 'mustache'
 
-export function renderHtml({ html, css, model }){
+export function renderHtml({ html, css, model }) {
   const body = Mustache.render(html, model)
-  // Wrap with a minimal doc that scales to A4 and embeds CSS
   return `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8" />
 <style>
-@page { size: A4; margin: 18mm 16mm; }
-html, body { background: #fff; }
-${css || ''}
+  /* Page & print control */
+  @page { size: A4; margin: 0; }
+  html, body { margin: 0; padding: 0; background: #fff; }
+  * { box-sizing: border-box; }
+  /* A4 screen wrapper: identical padding for all themes */
+  .page {
+    width: 210mm;
+    min-height: 297mm;
+    padding: 18mm 16mm;
+    margin: 0 auto;
+    font-family: Helvetica, Arial, sans-serif;
+    color: #111;
+  }
+  ${css || ''}
 </style>
 </head>
 <body>
-${body}
+  <div class="page">${body}</div>
 </body></html>`
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import "../styles/globals.css";
 import "../styles/resume.css";
+import "../styles/preview.css";
 import Head from "next/head";
 
 export default function MyApp({ Component, pageProps }) {

--- a/pages/results.js
+++ b/pages/results.js
@@ -1,15 +1,14 @@
 import { useEffect, useState } from 'react';
-import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import MainShell from '../components/layout/MainShell';
+import dynamic from 'next/dynamic';
+import PreviewFrame from '../components/PreviewFrame';
 import ControlsPanel from '../components/ui/ControlsPanel';
-import CoverLetterPdf from '../components/pdf/CoverLetterPdf';
 import { listTemplates, getTemplate } from '../templates';
-import { renderHtml } from '..//lib/renderHtmlTemplate';
-import { toTemplateModel } from '..//lib/templateModel';
+import { renderHtml } from '../lib/renderHtmlTemplate';
+import { toTemplateModel } from '../lib/templateModel';
 import { pdf } from '@react-pdf/renderer';
 
-const PDFViewer = dynamic(() => import('@react-pdf/renderer').then(m => m.PDFViewer), { ssr: false });
+const CoverLetterPdf = dynamic(() => import('../components/pdf/CoverLetterPdf'), { ssr: false });
 
 export default function ResultsPage() {
   const [result, setResult] = useState(null);
@@ -30,8 +29,9 @@ export default function ResultsPage() {
   useEffect(() => {
     if (!result) return;
     async function generateCover() {
+      const { default: CoverLetterPdfComponent } = await import('../components/pdf/CoverLetterPdf');
       const cBlob = await pdf(
-        <CoverLetterPdf text={result.coverLetter} accent={accent} density={density} atsMode={atsMode} />
+        <CoverLetterPdfComponent text={result.coverLetter} accent={accent} density={density} atsMode={atsMode} />
       ).toBlob();
       setCoverUrl((u) => {
         if (u) URL.revokeObjectURL(u);
@@ -47,7 +47,7 @@ export default function ResultsPage() {
     const res = await fetch(`/api/pdf?template=${tplId}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ data: appData })
+      body: JSON.stringify({ data: appData }),
     });
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
@@ -98,9 +98,21 @@ export default function ResultsPage() {
 
   if (!result) return null;
 
+  const appData = { ...result.resumeData, accent, density, ats: atsMode };
   const tpl = getTemplate(tplId);
-  const model = toTemplateModel({ ...result.resumeData, accent, density, ats: atsMode });
-  const html = tpl.engine === 'html' ? renderHtml({ html: tpl.html, css: tpl.css, model }) : null;
+  const model = toTemplateModel(appData);
+  const ReactPdfDoc =
+    tpl.engine === 'react-pdf'
+      ? (tpl.module?.DocumentFor || tpl.module?.default)
+        ? (tpl.module.DocumentFor || tpl.module.default)({ model })
+        : null
+      : null;
+  const htmlDoc = tpl.engine === 'html' ? renderHtml({ html: tpl.html, css: tpl.css, model }) : null;
+
+  const clDoc = (
+    <CoverLetterPdf text={result.coverLetter} accent={accent} density={density} atsMode={atsMode} />
+  );
+  const clTpl = { engine: 'react-pdf' };
 
   return (
     <>
@@ -108,11 +120,11 @@ export default function ResultsPage() {
         <title>Results – TailorCV</title>
         <meta
           name="description"
-          content="Preview and download your tailored CV with selectable HTML or React-PDF templates, consistent A4 output, and easy export options."
+          content="Preview and download your tailored CV and cover letter with consistent A4 frames, using HTML or React-PDF templates."
         />
       </Head>
-      <MainShell
-        left={
+      <div className="preview-grid">
+        <aside>
           <ControlsPanel
             accent={accent}
             setAccent={setAccent}
@@ -125,35 +137,23 @@ export default function ResultsPage() {
             onExportClPdf={downloadCoverPdf}
             onExportClDocx={downloadClDocx}
           />
-        }
-        right={
-          <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
-            <div className="space-y-4">
-              <select value={tplId} onChange={e => setTplId(e.target.value)} className="border p-2 rounded">
-                {templates.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
-              </select>
-              {tpl.engine === 'html' ? (
-                <iframe style={{width:'794px', height:'1123px', border:'0', boxShadow:'0 10px 30px rgba(0,0,0,.15)'}}
-                        srcDoc={html} />
-              ) : (
-                <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
-                  {(tpl.module.DocumentFor || tpl.module.default)({ model })}
-                </PDFViewer>
-              )}
-            </div>
-            <div id="cover-preview" className="h-[80vh]">
-              <PDFViewer showToolbar={false} className="w-full h-full border border-gray-800">
-                <CoverLetterPdf
-                  text={result.coverLetter}
-                  accent={accent}
-                  density={density}
-                  atsMode={atsMode}
-                />
-              </PDFViewer>
-            </div>
+          <div className="mt-4">
+            <select value={tplId} onChange={(e) => setTplId(e.target.value)} className="border p-2 rounded w-full">
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
           </div>
-        }
-      />
+        </aside>
+        <section>
+          <PreviewFrame engine={tpl.engine} htmlDoc={htmlDoc} ReactPdfDoc={ReactPdfDoc} />
+        </section>
+        <section id="cover-preview">
+          <PreviewFrame engine={clTpl.engine} htmlDoc={null} ReactPdfDoc={clDoc} />
+        </section>
+      </div>
     </>
   );
 }

--- a/styles/preview.css
+++ b/styles/preview.css
@@ -1,0 +1,13 @@
+.preview-grid {
+  display: grid;
+  grid-template-columns: 1fr 820px 820px; /* sidebar + two A4 previews */
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 1600px) {
+  .preview-grid { grid-template-columns: 1fr 820px; }
+}
+@media (max-width: 1100px) {
+  .preview-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- wrap HTML templates in A4 `.page` container for consistent margins
- add `<PreviewFrame>` with BlobProvider + iframe for clean A4 previews
- use unified preview grid layout and SEO-friendly metadata on results page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c09c0f87d4832994a6aaf6ce0db958