### PR TITLE
Fix react alias resolution and add root path alias

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,16 @@
+const path = require('path');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-      react: require.resolve('react'),
-      'react-dom': require.resolve('react-dom'),
+      'react$': require.resolve('react'),
+      'react-dom$': require.resolve('react-dom'),
+      '@': path.resolve(__dirname),
     };
     return config;
   },
 };
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Constrain React and ReactDOM webpack aliases to avoid breaking subpath resolution
- Add `@` alias pointing to project root for cleaner module imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0a553590883299d78ab816678e9f8