### PR TITLE
Render cover letter separately and shrink previews

### DIFF
--- a/components/PreviewFrame.jsx
+++ b/components/PreviewFrame.jsx
@@ -1,13 +1,26 @@
 'use client'
 import React from 'react'
+
 const A4 = { wpx: 794, hpx: 1123 }
+const SCALE = 0.55
 
 export default function PreviewFrame({ htmlDoc }) {
-  const style = {
+  const iframeStyle = {
     width: A4.wpx,
     height: A4.hpx,
     border: 0,
-    background: 'transparent'
+    background: 'transparent',
+    transform: `scale(${SCALE})`,
+    transformOrigin: 'top left'
   }
-  return <iframe style={style} srcDoc={htmlDoc} />
+  const wrapperStyle = {
+    width: A4.wpx * SCALE,
+    height: A4.hpx * SCALE,
+    overflow: 'hidden'
+  }
+  return (
+    <div style={wrapperStyle}>
+      <iframe style={iframeStyle} srcDoc={htmlDoc} />
+    </div>
+  )
 }

--- a/pages/results.js
+++ b/pages/results.js
@@ -6,6 +6,13 @@ import { listTemplates, getTemplate } from '../templates'
 import { renderHtml } from '../lib/renderHtmlTemplate'
 import { toTemplateModel } from '../lib/templateModel'
 
+function toHtmlParagraphs(text) {
+  return String(text || '')
+    .split(/\n+/)
+    .map(p => `<p>${p}</p>`)
+    .join('')
+}
+
 export default function ResultsPage() {
   const [result, setResult] = useState(null)
   const templates = listTemplates()
@@ -40,7 +47,14 @@ export default function ResultsPage() {
 
   async function downloadCoverPdf() {
     if (!result) return
-    const data = { ...result.resumeData, coverLetter: result.coverLetter, accent, density, ats: atsMode, isCoverLetter: true }
+    const data = {
+      ...result.resumeData,
+      coverLetter: toHtmlParagraphs(result.coverLetter),
+      accent,
+      density,
+      ats: atsMode,
+      isCoverLetter: true
+    }
     const res = await fetch(`/api/pdf?template=${tplId}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -91,13 +105,13 @@ export default function ResultsPage() {
   const tpl = getTemplate(tplId)
   const model = toTemplateModel(appData)
   const cvHtml = renderHtml({ html: tpl.html, css: tpl.css, model })
-  const coverModel = { ...model, coverLetter: result.coverLetter, isCoverLetter: true }
+  const coverModel = { ...model, coverLetter: toHtmlParagraphs(result.coverLetter), isCoverLetter: true }
   const coverHtml = renderHtml({ html: tpl.html, css: tpl.css, model: coverModel })
 
   return (
     <>
       <Head>
-        <title>Results – TailorCV</title>
+        <title>Results – Tailored CV & Cover Letter | TailorCV</title>
         <meta
           name="description"
           content="Preview and download your tailored CV and cover letter with unified HTML A4 templates."
@@ -105,7 +119,7 @@ export default function ResultsPage() {
       </Head>
       <div style={{
         display:'grid',
-        gridTemplateColumns:'340px 1fr 1fr',
+        gridTemplateColumns:'340px auto auto',
         gap:'24px',
         alignItems:'start'
       }}>

--- a/templates/minimal-html/template.html
+++ b/templates/minimal-html/template.html
@@ -1,5 +1,13 @@
 <h1>{{name}}</h1>
 <p class="meta">{{label}} • {{email}} • {{phone}} • {{url}}</p>
+
+{{#isCoverLetter}}
+<div class="section">
+  {{{coverLetter}}}
+</div>
+{{/isCoverLetter}}
+
+{{^isCoverLetter}}
 <div class="section">
   <h2>PROFILE</h2>
   <p>{{summary}}</p>
@@ -23,3 +31,4 @@
       <span style="float:right" class="meta">{{start}} — {{end}}</span></div>
   {{/education}}
 </div>
+{{/isCoverLetter}}


### PR DESCRIPTION
## Summary
- Scale down document previews for better readability
- Render cover letter separately using paragraph formatting
- Update results page SEO title

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0a9ed1d948329ab74217acca2a56c