### PR TITLE
Unify job title field in resume model

### DIFF
--- a/components/ResumeWizard.js
+++ b/components/ResumeWizard.js
@@ -40,7 +40,7 @@ const schemas = {
   work: z.object({
     experience: z.array(z.object({
       company: z.string().min(1, 'Company required'),
-      role: z.string().min(1, 'Role required'),
+      title: z.string().min(1, 'Job title required'),
       location: z.string().optional(),
       start: z.string().optional(),
       end: z.string().optional(),
@@ -119,7 +119,7 @@ export default function ResumeWizard({ initialData, onComplete, autosaveKey }) {
 
   function addExp() {
     const exps = getValues('experience');
-    setValue('experience', [...exps, { company:'', role:'', start:'', end:'', location:'', bullets:[] }]);
+    setValue('experience', [...exps, { company:'', title:'', start:'', end:'', location:'', bullets:[] }]);
   }
   function updateExp(i, val) {
     const exps = getValues('experience');

--- a/components/wizard/ExperienceCard.jsx
+++ b/components/wizard/ExperienceCard.jsx
@@ -35,11 +35,11 @@ export default function ExperienceCard({ value, onChange, onRemove, onDuplicate,
           />
         </div>
         <div className="space-y-1">
-          <label className="text-xs font-medium text-zinc-600">Role*</label>
+          <label className="text-xs font-medium text-zinc-600">Job Title*</label>
           <input
             className="h-11 w-full rounded-xl border border-zinc-300 px-3 py-2 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 bg-transparent"
-            value={value.role}
-            onChange={e => updateField('role', e.target.value)}
+            value={value.title}
+            onChange={e => updateField('title', e.target.value)}
             required
           />
         </div>

--- a/lib/normalizeResume.js
+++ b/lib/normalizeResume.js
@@ -72,13 +72,13 @@ export function normalizeResumeData(raw = {}) {
   out.experience = out.experience
     .map((x) => ({
       company: String(x?.company || "").trim(),
-      role: String(x?.role || "").trim(),
+      title: String(x?.title || x?.role || "").trim(),
       start: toYmOrNull(x?.start),
       end: toYmOrNull(x?.end),
       location: x?.location ? String(x.location) : undefined,
       bullets: toArray(x?.bullets),
     }))
-    .filter((e) => e.company || e.role || e.bullets.length);
+    .filter((e) => e.company || e.title || e.bullets.length);
 
   // Education: coerce dates and keep if has any content
   out.education = out.education

--- a/lib/renderUtils.js
+++ b/lib/renderUtils.js
@@ -1,6 +1,6 @@
 export const limitExperience = (experience = [], maxExp = 2, maxBullets = 2) =>
   (experience || [])
-    .filter(exp => exp && exp.title)
+    .filter(exp => exp && exp.title && exp.title.trim())
     .slice(0, maxExp)
     .map(exp => ({
       ...exp,

--- a/lib/resumeSchema.js
+++ b/lib/resumeSchema.js
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const ExperienceItem = z.object({
   company: z.string(),
-  role: z.string(),
+  title: z.string(),
   start: z.string(),              // "2021-05"
   end: z.string().nullable(),     // null => Present
   bullets: z.array(z.string()).min(1),

--- a/pages/api/export-docx-structured.js
+++ b/pages/api/export-docx-structured.js
@@ -29,7 +29,7 @@ export default async function handler(req, res) {
 
     docChildren.push(h("Experience"));
     (data.experience || []).forEach((x) => {
-      const heading = `${x.company} — ${x.role}`;
+      const heading = `${x.company} — ${x.title}`;
       const dates = `${x.start} – ${x.end || "Present"}`;
       docChildren.push(new Paragraph({ children: [
         new TextRun({ text: heading, bold: true }),

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -169,7 +169,7 @@ You output ONLY JSON with keys:
 STRICT RULES:
 - Treat ALLOWED_SKILLS as an allow-list. resumeData.skills MUST be a subset of ALLOWED_SKILLS.
 - Do NOT add tools/tech/frameworks in skills or experience if they are not in ALLOWED_SKILLS.
-    - For resumeData.experience[], each item must include company, role, start, end, location?, bullets[]. Start/end dates must come from the candidate's resume and must not be fabricated. Bullets must begin with strong action verbs, include quantifiable outcomes when possible, and align with job description keywords that are supported by the resume.
+    - For resumeData.experience[], each item must include company, title, start, end, location?, bullets[]. Start/end dates must come from the candidate's resume and must not be fabricated. Bullets must begin with strong action verbs, include quantifiable outcomes when possible, and align with job description keywords that are supported by the resume.
 - For resumeData.education[], each item must include school, degree, start, end, grade? Dates and grade must come from the candidate's resume and must not be fabricated.
 - The coverLetterText MUST NOT claim direct experience with non-allowed skills. When mentioning JOB_ONLY_SKILLS, express willingness to learn or highlight transferable experience using phrasing like "While I haven't used X directly, I have Y which maps to X by Z."
 - The coverLetterText must adopt a ${tone} tone.

--- a/pages/api/parse-resume.js
+++ b/pages/api/parse-resume.js
@@ -50,7 +50,7 @@ export default async function handler(req,res){
     if (!resumeText) return res.status(400).json({ error:"No readable file" });
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const system = `Output ONLY JSON: {"resumeData":{name,title?,email?,phone?,location?,summary?,links[],skills[],experience[],education[]}}
-Experience items must include company, role, start, end, location?, bullets[].
+Experience items must include company, title, start, end, location?, bullets[].
 Education items must include school, degree, start, end, grade?.
 Use ONLY details present in RESUME_TEXT. Do not fabricate.`;
     const user = `RESUME_TEXT:\n${resumeText}`;


### PR DESCRIPTION
## Summary
- rename experience `role` field to `title`
- normalize legacy `role` data and update schema, wizard, and exports
- ensure experience limiting filters on the new `title` field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node -e "const {limitExperience}=require('./lib/renderUtils'); console.log(limitExperience([{title:'Engineer', company:'Co', bullets:['Did stuff']}],3,2));"`
- `node --experimental-specifier-resolution=node -e "(async () => { const handler = (await import('./pages/api/download-cv.js')).default; const req={method:'POST', body:{template:'professional', accent:'#000', data:{resumeData:{name:'Jane Doe', email:'jane@example.com', experience:[{title:'Dev', company:'Co', start:'2022-01', bullets:['Built stuff']}], education:[]}}}}; const res={status:c=>{res.statusCode=c; return res;}, setHeader:()=>{}, send:buf=>{console.log('PDF bytes', buf.length);}, json:obj=>{console.log('JSON',res.statusCode,obj);}}; await handler(req,res); })();"` *(fails: Cannot find module '/workspace/resume/lib/renderUtils' imported from /workspace/resume/pages/api/download-cv.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d36e20148329a088fe2a0c0ba9b9