### PR TITLE
Add comprehensive SEO enhancements

### DIFF
--- a/components/SeoHead.js
+++ b/components/SeoHead.js
@@ -1,0 +1,29 @@
+import Head from 'next/head';
+
+export default function SeoHead({
+  title = 'TailoredCV.app – AI-Powered Resume Optimization',
+  description = 'Create ATS-friendly resumes and cover letters with AI. Upload your existing resume or start from scratch - get hired faster with professionally tailored documents.',
+  keywords = 'AI resume, ATS resume, cover letter generator, professional CV, TailoredCV',
+  canonical = 'https://tailoredcv.app',
+  ogImage = 'https://tailoredcv.app/og-image.png',
+  robots = 'index,follow',
+}) {
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta name="keywords" content={keywords} />
+      <meta name="robots" content={robots} />
+      <link rel="canonical" href={canonical} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:image" content={ogImage} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={ogImage} />
+    </Head>
+  );
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,19 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <meta charSet="UTF-8" />
+        <meta httpEquiv="x-ua-compatible" content="IE=edge" />
+        <link rel="icon" href="/favicon.png" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#1e3a8a" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/account.js
+++ b/pages/account.js
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import Head from 'next/head';
 import Link from 'next/link';
 import { Settings, CreditCard, User, Shield, AlertTriangle, ExternalLink, Clock } from 'lucide-react';
+import SeoHead from '../components/SeoHead';
 
 export default function Account() {
   const { data: session, status } = useSession();
@@ -86,10 +86,12 @@ export default function Account() {
 
   return (
     <>
-      <Head>
-        <title>Account Settings - TailoredCV.app</title>
-        <meta name="description" content="Manage your account settings, billing, and subscription." />
-      </Head>
+      <SeoHead
+        title="Account Settings - TailoredCV.app"
+        description="Manage your account settings, billing, and subscription."
+        canonical="https://tailoredcv.app/account"
+        robots="noindex,nofollow"
+      />
 
       <div className="min-h-screen bg-gray-50 py-8">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/pages/account/cancel-subscription.js
+++ b/pages/account/cancel-subscription.js
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import Head from 'next/head';
 import Link from 'next/link';
 import { AlertTriangle, ArrowLeft, ExternalLink, CreditCard, CheckCircle } from 'lucide-react';
+import SeoHead from '../../components/SeoHead';
 
 export default function CancelSubscription() {
   const { data: session, status } = useSession();
@@ -85,10 +85,12 @@ export default function CancelSubscription() {
 
   return (
     <>
-      <Head>
-        <title>Cancel Subscription - TailoredCV.app</title>
-        <meta name="description" content="Cancel your TailoredCV.app subscription" />
-      </Head>
+      <SeoHead
+        title="Cancel Subscription - TailoredCV.app"
+        description="Cancel your TailoredCV.app subscription"
+        canonical="https://tailoredcv.app/account/cancel-subscription"
+        robots="noindex,nofollow"
+      />
 
       <div className="min-h-screen bg-gray-50 py-8">
         <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/pages/account/delete-account.js
+++ b/pages/account/delete-account.js
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import Head from 'next/head';
 import Link from 'next/link';
 import { AlertTriangle, ArrowLeft, Trash2, Shield, Database, FileText, Clock, CheckCircle, X } from 'lucide-react';
+import SeoHead from '../../components/SeoHead';
 
 export default function DeleteAccount() {
   const { data: session, status } = useSession();
@@ -146,10 +146,12 @@ export default function DeleteAccount() {
     
     return (
       <>
-        <Head>
-          <title>Account Deletion Scheduled - TailoredCV.app</title>
-          <meta name="description" content="Your account deletion is scheduled" />
-        </Head>
+        <SeoHead
+          title="Account Deletion Scheduled - TailoredCV.app"
+          description="Your account deletion is scheduled"
+          canonical="https://tailoredcv.app/account/delete-account"
+          robots="noindex,nofollow"
+        />
 
         <div className="min-h-screen bg-gradient-to-br from-red-50 via-orange-50 to-yellow-50">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">
@@ -235,10 +237,12 @@ export default function DeleteAccount() {
 
   return (
     <>
-      <Head>
-        <title>Delete Account - TailoredCV.app</title>
-        <meta name="description" content="Delete your TailoredCV.app account permanently" />
-      </Head>
+      <SeoHead
+        title="Delete Account - TailoredCV.app"
+        description="Delete your TailoredCV.app account permanently"
+        canonical="https://tailoredcv.app/account/delete-account"
+        robots="noindex,nofollow"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-red-50 via-pink-50 to-orange-50">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">

--- a/pages/help/getting-started.js
+++ b/pages/help/getting-started.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import Head from 'next/head';
 import { ArrowLeft, Play, Download, Edit, Zap, CheckCircle } from 'lucide-react';
 import Link from 'next/link';
+import SeoHead from '../../components/SeoHead';
 
 export default function GettingStarted() {
   return (
     <>
-      <Head>
-        <title>Getting Started Guide – TailoredCV.app</title>
-        <meta name="description" content="Learn how to create your first resume with TailoredCV.app. Step-by-step guide to get you started quickly." />
-      </Head>
+      <SeoHead
+        title="Getting Started Guide – TailoredCV.app"
+        description="Learn how to create your first resume with TailoredCV.app. Step-by-step guide to get you started quickly."
+        canonical="https://tailoredcv.app/help/getting-started"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/help/templates.js
+++ b/pages/help/templates.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import Head from 'next/head';
 import { ArrowLeft, Briefcase, Palette, Users, Code, GraduationCap, CheckCircle, AlertCircle } from 'lucide-react';
 import Link from 'next/link';
+import SeoHead from '../../components/SeoHead';
 
 export default function TemplateGuidelines() {
   return (
     <>
-      <Head>
-        <title>Template Guidelines – TailoredCV.app</title>
-        <meta name="description" content="Learn how to choose the right resume template for your industry and career level. Professional template guidelines and best practices." />
-      </Head>
+      <SeoHead
+        title="Template Guidelines – TailoredCV.app"
+        description="Learn how to choose the right resume template for your industry and career level. Professional template guidelines and best practices."
+        canonical="https://tailoredcv.app/help/templates"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/help/troubleshooting.js
+++ b/pages/help/troubleshooting.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import Head from 'next/head';
 import { ArrowLeft, Search, ChevronDown, ChevronRight, AlertCircle, CheckCircle, Download, FileText, Zap } from 'lucide-react';
 import Link from 'next/link';
+import SeoHead from '../../components/SeoHead';
 
 export default function Troubleshooting() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -169,10 +169,11 @@ export default function Troubleshooting() {
 
   return (
     <>
-      <Head>
-        <title>Troubleshooting Guide – TailoredCV.app</title>
-        <meta name="description" content="Find solutions to common issues with TailoredCV.app. Troubleshooting guide for download problems, formatting issues, and technical support." />
-      </Head>
+      <SeoHead
+        title="Troubleshooting Guide – TailoredCV.app"
+        description="Find solutions to common issues with TailoredCV.app. Troubleshooting guide for download problems, formatting issues, and technical support."
+        canonical="https://tailoredcv.app/help/troubleshooting"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,10 @@
-import Head from 'next/head';
 import HeroUpload from '../components/ui/HeroUpload';
+import SeoHead from '../components/SeoHead';
 
 export default function Home(){
   return (
     <>
-      <Head>
-        <title>TailoredCV.app – AI-Powered Resume Optimization</title>
-        <meta name="description" content="Create ATS-friendly resumes and cover letters with AI. Upload your existing resume or start from scratch - get hired faster with professionally tailored documents." />
-      </Head>
+      <SeoHead canonical="https://tailoredcv.app/" />
       <HeroUpload />
     </>
   );

--- a/pages/my-resumes.js
+++ b/pages/my-resumes.js
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import Head from 'next/head';
 import Link from 'next/link';
 import { Clock, FileText, Calendar, Trash2, Edit, Crown } from 'lucide-react';
+import SeoHead from '../components/SeoHead';
 
 export default function MyResumes() {
   const { data: session, status } = useSession();
@@ -121,10 +121,12 @@ export default function MyResumes() {
 
   return (
     <>
-      <Head>
-        <title>My Saved Resumes – TailoredCV.app</title>
-        <meta name="description" content="View and manage your saved resumes" />
-      </Head>
+      <SeoHead
+        title="My Saved Resumes – TailoredCV.app"
+        description="View and manage your saved resumes"
+        canonical="https://tailoredcv.app/my-resumes"
+        robots="noindex,nofollow"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Head from 'next/head';
+import SeoHead from '../components/SeoHead';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { Check, Crown, Sparkles, ArrowRight, Zap } from 'lucide-react';
@@ -127,10 +127,11 @@ export default function PricingPage() {
 
   return (
     <>
-      <Head>
-        <title>Pricing - TailoredCV.app</title>
-        <meta name="description" content="Choose the perfect plan for your resume and cover letter needs. Start free or unlock premium features with Pro." />
-      </Head>
+      <SeoHead
+        title="Pricing - TailoredCV.app"
+        description="Choose the perfect plan for your resume and cover letter needs. Start free or unlock premium features with Pro."
+        canonical="https://tailoredcv.app/pricing"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import Head from 'next/head';
 import Link from 'next/link';
 import { Shield, User, Lock, Eye } from 'lucide-react';
+import SeoHead from '../components/SeoHead';
 
 export default function PrivacyPolicy() {
   return (
     <>
-      <Head>
-        <title>Privacy Policy - TailoredCV.app</title>
-        <meta name="description" content="Learn how TailoredCV.app collects, uses, and protects your personal information and resume data." />
-        <meta name="robots" content="index, follow" />
-      </Head>
+      <SeoHead
+        title="Privacy Policy - TailoredCV.app"
+        description="Learn how TailoredCV.app collects, uses, and protects your personal information and resume data."
+        canonical="https://tailoredcv.app/privacy"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/results.js
+++ b/pages/results.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import { limitCoverLetter } from '../lib/renderUtils';
 import ResumeTemplate from '../components/ResumeTemplate';
+import SeoHead from '../components/SeoHead';
 import { 
   FileText, 
   Download, 
@@ -494,10 +494,12 @@ export default function ResultsPage() {
 
   return (
     <>
-      <Head>
-        <title>{headerContent.title} – TailoredCV.app</title>
-        <meta name="description" content={headerContent.description}/>
-      </Head>
+      <SeoHead
+        title={`${headerContent.title} – TailoredCV.app`}
+        description={headerContent.description}
+        canonical="https://tailoredcv.app/results"
+        robots="noindex,nofollow"
+      />
       
       {/* Modern Hero Section */}
       <div className="relative overflow-hidden">

--- a/pages/support.js
+++ b/pages/support.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import Head from 'next/head';
 import Link from 'next/link';
 import { Mail, MessageCircle, Book, FileText, Clock, CheckCircle, AlertCircle } from 'lucide-react';
+import SeoHead from '../components/SeoHead';
 
 export default function Support() {
   const [formData, setFormData] = useState({
@@ -67,10 +67,11 @@ export default function Support() {
 
   return (
     <>
-      <Head>
-        <title>Support – TailoredCV.app</title>
-        <meta name="description" content="Get help with TailoredCV.app. Find answers to common questions or contact our support team for assistance with your resume and cover letter needs." />
-      </Head>
+      <SeoHead
+        title="Support – TailoredCV.app"
+        description="Get help with TailoredCV.app. Find answers to common questions or contact our support team for assistance with your resume and cover letter needs."
+        canonical="https://tailoredcv.app/support"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Hero Section */}

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import Head from 'next/head';
 import Link from 'next/link';
 import { FileText, AlertTriangle, Scale, CreditCard } from 'lucide-react';
+import SeoHead from '../components/SeoHead';
 
 export default function TermsOfService() {
   return (
     <>
-      <Head>
-        <title>Terms of Service - TailoredCV.app</title>
-        <meta name="description" content="Terms and conditions for using TailoredCV.app resume and cover letter generation service." />
-        <meta name="robots" content="index, follow" />
-      </Head>
+      <SeoHead
+        title="Terms of Service - TailoredCV.app"
+        description="Terms and conditions for using TailoredCV.app resume and cover letter generation service."
+        canonical="https://tailoredcv.app/terms"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
         {/* Header */}

--- a/pages/wizard.js
+++ b/pages/wizard.js
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import { Clock, AlertCircle } from 'lucide-react';
 import ResumeWizard from '../components/ResumeWizard';
+import SeoHead from '../components/SeoHead';
 
 export default function WizardPage(){
   const router = useRouter();
@@ -90,10 +90,12 @@ export default function WizardPage(){
 
   return (
     <>
-      <Head>
-        <title>Resume Wizard – TailoredCV.app</title>
-        <meta name="description" content="Step-by-step resume builder with real-time template rendering and one-click PDF downloads." />
-      </Head>
+      <SeoHead
+        title="Resume Wizard – TailoredCV.app"
+        description="Step-by-step resume builder with real-time template rendering and one-click PDF downloads."
+        canonical="https://tailoredcv.app/wizard"
+        robots="noindex,nofollow"
+      />
       
       {/* Use Most Recent Resume Section */}
       {session?.user && hasLatestResume && showRecentCVSection && (

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "TailoredCV.app",
+  "short_name": "TailoredCV",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "64x64",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#1e3a8a",
+  "background_color": "#ffffff"
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://tailoredcv.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tailoredcv.app/</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/pricing</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/help/getting-started</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/help/templates</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/help/troubleshooting</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/support</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/privacy</loc>
+  </url>
+  <url>
+    <loc>https://tailoredcv.app/terms</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add reusable `SeoHead` component providing canonical URLs, Open Graph, and Twitter metadata
- embed SEO metadata across pages and mark account areas `noindex`
- introduce sitemap, robots.txt, and manifest for better crawlability
- remove placeholder image assets so icons can be added manually

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c57fd0d483299354917e8cfcbfc9