### PR TITLE
fix: improve dark mode styling

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -8,7 +8,9 @@ export default function Document() {
         <meta httpEquiv="x-ua-compatible" content="IE=edge" />
         <link rel="icon" href="/favicon.png" />
         <link rel="manifest" href="/manifest.json" />
-        <meta name="theme-color" content="#1e3a8a" />
+        <meta name="color-scheme" content="light dark" />
+        <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafafa" />
+        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0a0a0b" />
       </Head>
       <body>
         <Main />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,7 +99,7 @@ body {
 
 /* Legacy styles kept for compatibility */
 /* Simple global styles */
-body { margin: 0; background: #f7f7f7; color: #333; }
+body { margin: 0; }
 .app-container { min-height: 100vh; }
 .container { max-width: 768px; margin: 0 auto; padding: 1rem; }
 .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; }


### PR DESCRIPTION
## Summary
- remove legacy body colors so Tailwind dark classes render correctly
- add light/dark theme-color and color-scheme meta tags for better dark mode and SEO

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5f61a5658832993d2dc6bfffa4415