### PR TITLE
feat: add analytics and cookie consent

### DIFF
--- a/components/ui/CookieBanner.jsx
+++ b/components/ui/CookieBanner.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+
+export default function CookieBanner() {
+  const { data: session } = useSession();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('cookieConsent') : null;
+    if (stored) {
+      if (stored === 'accepted' && typeof window.gtag === 'function') {
+        window.gtag('consent', 'update', { analytics_storage: 'granted' });
+      }
+      return;
+    }
+
+    const pref = session?.user?.cookiePreferences?.analytics;
+    if (pref !== undefined) {
+      localStorage.setItem('cookieConsent', pref ? 'accepted' : 'rejected');
+      if (pref && typeof window.gtag === 'function') {
+        window.gtag('consent', 'update', { analytics_storage: 'granted' });
+      }
+    } else {
+      setVisible(true);
+      if (typeof window.gtag === 'function') {
+        window.gtag('consent', 'default', { analytics_storage: 'denied' });
+      }
+    }
+  }, [session]);
+
+  const handleChoice = async (accepted) => {
+    localStorage.setItem('cookieConsent', accepted ? 'accepted' : 'rejected');
+    if (accepted && typeof window.gtag === 'function') {
+      window.gtag('consent', 'update', { analytics_storage: 'granted' });
+    }
+    if (session?.user?.id) {
+      try {
+        await fetch('/api/user/cookie-preferences', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ analytics: accepted })
+        });
+      } catch (err) {
+        console.error('Failed to save cookie preference', err);
+      }
+    }
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-gray-800 text-white p-4 z-50 text-sm">
+      <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="flex-1">
+          We use cookies to improve your experience and for analytics. You can accept or decline analytics cookies.
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleChoice(false)}
+            className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600"
+          >
+            Decline
+          </button>
+          <button
+            onClick={() => handleChoice(true)}
+            className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-500"
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,6 +8,7 @@ import Footer from "../components/ui/Footer";
 import { SessionProvider } from "next-auth/react";
 import { LanguageProvider } from "../contexts/LanguageContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
+import CookieBanner from "../components/ui/CookieBanner";
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
   return (
@@ -57,6 +58,7 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
               <Component {...pageProps} />
             </main>
             <Footer />
+            <CookieBanner />
           </div>
         </LanguageProvider>
       </ThemeProvider>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -11,6 +11,21 @@ export default function Document() {
         <meta name="color-scheme" content="light dark" />
         <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafafa" />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0a0a0b" />
+        <script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-13VHZQMFPJ"
+        ></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('consent', 'default', { analytics_storage: 'denied' });
+              gtag('config', 'G-13VHZQMFPJ');
+            `,
+          }}
+        />
       </Head>
       <body>
         <Main />

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -47,7 +47,20 @@ export const authOptions = {
       return token
     },
     async session({ session, token }) {
-      if (token?.userId) session.user.id = token.userId
+      if (token?.userId) {
+        session.user.id = token.userId
+        try {
+          const user = await prisma.user.findUnique({
+            where: { id: token.userId },
+            select: { cookiePreferences: true }
+          })
+          if (user?.cookiePreferences) {
+            session.user.cookiePreferences = user.cookiePreferences
+          }
+        } catch (error) {
+          console.error('Session callback error:', error)
+        }
+      }
       return session
     },
     async signIn({ user, account, profile }) {

--- a/pages/api/user/cookie-preferences.js
+++ b/pages/api/user/cookie-preferences.js
@@ -1,0 +1,39 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { prisma } from '../../../lib/prisma.js';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { cookiePreferences: true }
+      });
+      return res.status(200).json(user?.cookiePreferences || {});
+    } catch (error) {
+      console.error('Cookie preference fetch error:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const { analytics } = req.body;
+    try {
+      await prisma.user.update({
+        where: { id: session.user.id },
+        data: { cookiePreferences: { analytics } }
+      });
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      console.error('Cookie preference update error:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -8,7 +8,7 @@ export default function PrivacyPolicy() {
     <>
       <SeoHead
         title="Privacy Policy - TailoredCV.app"
-        description="Learn how TailoredCV.app collects, uses, and protects your personal information and resume data."
+        description="Learn how TailoredCV.app collects, uses, and protects your personal information, including our use of cookies and analytics."
         canonical="https://tailoredcv.app/privacy"
       />
 
@@ -170,9 +170,14 @@ export default function PrivacyPolicy() {
                 <li>Analyze site usage and performance</li>
                 <li>Improve user experience</li>
               </ul>
-              
+
               <p className="text-gray-700 mt-4">
-                You can control cookies through your browser settings, but disabling cookies may affect functionality.
+                We use Google Analytics to better understand how visitors interact with TailoredCV.app. Analytics cookies are
+                optional and you can accept or decline them via the cookie banner. If you have an account, your preference is
+                saved with your profile.
+              </p>
+              <p className="text-gray-700 mt-4">
+                You can also control cookies through your browser settings, but disabling cookies may affect functionality.
               </p>
             </section>
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   sessions                Session[]
   savedResumes            SavedResume[]
   accountDeletionRequest  AccountDeletionRequest?
+  cookiePreferences       Json?
 }
 
 model VerificationToken {


### PR DESCRIPTION
## Summary
- add Google Analytics tag
- implement cookie banner with preference storage
- update privacy policy and user model for cookie preferences

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5f78b61748329b5453bd892bc5086